### PR TITLE
[#155217850] pricing plans valid from constraint

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -23,8 +23,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	ThreeMonthsInHours = 1488
+	OneMonthInHours    = 720
+)
+
 var (
-	now = time.Now().UTC().Round(time.Second)
+	now = time.Date(2017, time.October, 1, 0, 0, 0, 0, time.UTC)
 )
 
 var _ = Describe("API", func() {
@@ -48,7 +53,7 @@ var _ = Describe("API", func() {
 		X10ComputePlan = fixtures.Plan{
 			ID:        1,
 			Name:      "x10-compute-plan",
-			ValidFrom: now.Add(-(100 * 24 * time.Hour)),
+			ValidFrom: monthsAgo(3),
 			PlanGuid:  db.ComputePlanGuid,
 			Components: []fixtures.PricingPlanComponent{
 				{
@@ -66,7 +71,7 @@ var _ = Describe("API", func() {
 		X4ComputePlan = fixtures.Plan{
 			ID:        2,
 			Name:      "x4-compute-plan",
-			ValidFrom: now.Add(-(10 * 24 * time.Hour)),
+			ValidFrom: monthsAgo(1),
 			PlanGuid:  db.ComputePlanGuid,
 			Components: []fixtures.PricingPlanComponent{
 				{
@@ -200,12 +205,12 @@ var _ = Describe("API", func() {
 			{
 				Name: "should return 2 compute usage row for a pair of STARTED / STOPPED app events (1x instance) that spans a pricing_plan boundry",
 				RequestQuery: url.Values{
-					"from": []string{now.Add(-(30 * 24 * time.Hour)).Format(time.RFC3339)},
+					"from": []string{monthsAgo(3).Format(time.RFC3339)},
 					"to":   []string{now.Format(time.RFC3339)},
 				},
 				AppEvents: []cf.UsageEvent{
 					{
-						MetaData: cf.MetaData{CreatedAt: now.Add(-(20 * 24 * time.Hour))},
+						MetaData: cf.MetaData{CreatedAt: monthsAgo(3)},
 						EntityRaw: json.RawMessage(`{
 							"state": "STARTED",
 							"app_guid": "app",
@@ -239,9 +244,9 @@ var _ = Describe("API", func() {
 						PricingPlanId:   X10ComputePlan.ID,
 						Name:            "app_name",
 						MemoryInMb:      512,
-						From:            now.Add(-(20 * 24 * time.Hour)),
-						To:              now.Add(-(10 * 24 * time.Hour)),
-						Price:           10 * (24 * 60 * 60) * 10,
+						From:            monthsAgo(3),
+						To:              monthsAgo(1),
+						Price:           ThreeMonthsInHours * (60 * 60) * 10,
 					},
 					{
 						Guid:            "app",
@@ -251,9 +256,9 @@ var _ = Describe("API", func() {
 						PricingPlanId:   X4ComputePlan.ID,
 						Name:            "app_name",
 						MemoryInMb:      512,
-						From:            now.Add(-(10 * 24 * time.Hour)),
+						From:            monthsAgo(1),
 						To:              now,
-						Price:           10 * (24 * 60 * 60) * 4,
+						Price:           OneMonthInHours * (60 * 60) * 4,
 					},
 				},
 			},

--- a/api/fixtures_test.go
+++ b/api/fixtures_test.go
@@ -11,12 +11,16 @@ func ago(t time.Duration) time.Time {
 	return now.Add(0 - t)
 }
 
+func monthsAgo(months int) time.Time {
+	return now.AddDate(0, -months, 0)
+}
+
 var planFixtures = Plans{
 	{
 		ID:        10,
 		Name:      "ComputePlanA",
 		PlanGuid:  db.ComputePlanGuid,
-		ValidFrom: ago(100 * time.Hour),
+		ValidFrom: monthsAgo(3),
 		Components: []PricingPlanComponent{
 			{
 				ID:      101,
@@ -34,7 +38,7 @@ var planFixtures = Plans{
 		ID:        11,
 		Name:      "ComputePlanB",
 		PlanGuid:  db.ComputePlanGuid,
-		ValidFrom: ago(1 * time.Hour),
+		ValidFrom: monthsAgo(1),
 		Components: []PricingPlanComponent{
 			{
 				ID:      111,
@@ -47,7 +51,7 @@ var planFixtures = Plans{
 		ID:        20,
 		Name:      "ServicePlanA",
 		PlanGuid:  "00000000-0000-0000-0000-100000000000",
-		ValidFrom: ago(100 * time.Hour),
+		ValidFrom: monthsAgo(3),
 		Components: []PricingPlanComponent{
 			{
 				ID:      201,
@@ -65,7 +69,7 @@ var planFixtures = Plans{
 		ID:        30,
 		Name:      "ServicePlanB",
 		PlanGuid:  "00000000-0000-0000-0000-200000000000",
-		ValidFrom: ago(100 * time.Hour),
+		ValidFrom: monthsAgo(3),
 		Components: []PricingPlanComponent{
 			{
 				ID:      301,
@@ -99,7 +103,7 @@ var orgsFixtures = Orgs{
 					State:                 "STARTED",
 					InstanceCount:         1,
 					MemoryInMBPerInstance: 64,
-					Time: ago(10 * time.Hour),
+					Time: monthsAgo(3),
 				},
 			},
 		},

--- a/api/resource_usage_test.go
+++ b/api/resource_usage_test.go
@@ -26,6 +26,10 @@ func agoRFC3339(d time.Duration) string {
 	return ago(d).Format(time.RFC3339)
 }
 
+func monthsAgoRFC3339(months int) string {
+	return monthsAgo(months).Format(time.RFC3339)
+}
+
 var nowRFC3339 = now.Format(time.RFC3339)
 
 var _ = Describe("API", func() {
@@ -88,13 +92,6 @@ var _ = Describe("API", func() {
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to unmarshal json: %s\nbody: %s", err, string(body)))
 	}
 
-	var request = func(path string, v interface{}) {
-		doRequest(path, v, map[string]string{
-			"from": ago(100 * time.Hour).Format(time.RFC3339Nano),
-			"to":   now.Format(time.RFC3339Nano),
-		})
-	}
-
 	var requestRanged = func(url string, from time.Time, to time.Time, v interface{}) {
 		doRequest(url, v, map[string]string{
 			"from": from.Format(time.RFC3339Nano),
@@ -149,7 +146,9 @@ var _ = Describe("API", func() {
 	var itShouldFetchPricingPlanComponents = func() {
 		path := "/pricing_plan_components"
 		var out interface{}
-		request(path, &out)
+		from := monthsAgo(1)
+		to := now
+		requestRanged(path, from, to, &out)
 		ExpectJSON(out, []map[string]interface{}{
 			{
 				"formula":         "($time_in_seconds / 60 / 60) * $memory_in_mb * 0.7",
@@ -193,7 +192,9 @@ var _ = Describe("API", func() {
 	var itShouldFetchPricingPlanComponentsByPlan = func() {
 		path := "/pricing_plans/10/components"
 		var out interface{}
-		request(path, &out)
+		from := monthsAgo(1)
+		to := now
+		requestRanged(path, from, to, &out)
 		ExpectJSON(out, []map[string]interface{}{
 			{
 				"formula":         "($time_in_seconds / 60 / 60) * $memory_in_mb * 0.7",
@@ -213,7 +214,9 @@ var _ = Describe("API", func() {
 	var itShouldFetchPricingPlanComponentById = func() {
 		path := "/pricing_plan_components/101"
 		var out interface{}
-		request(path, &out)
+		from := monthsAgo(1)
+		to := now
+		requestRanged(path, from, to, &out)
 		ExpectJSON(out, map[string]interface{}{
 			"formula":         "($time_in_seconds / 60 / 60) * $memory_in_mb * 0.7",
 			"id":              101,
@@ -236,15 +239,17 @@ var _ = Describe("API", func() {
 
 			It("should return pricing totals for each org", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 633650,
+						"price_in_pence": 9932850,
 					},
 					{
 						"org_guid":       "00000002-0000-0000-0000-000000000000",
-						"price_in_pence": 185950,
+						"price_in_pence": 294750,
 					},
 				})
 			})
@@ -275,10 +280,12 @@ var _ = Describe("API", func() {
 
 			It("should return org total", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, map[string]interface{}{
 					"org_guid":       guid,
-					"price_in_pence": 633650,
+					"price_in_pence": 9932850,
 				})
 			})
 
@@ -302,16 +309,18 @@ var _ = Describe("API", func() {
 
 			It("should return space totals for the given org", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 70400,
+						"price_in_pence": 9216000,
 						"space_guid":     "00000001-0001-0000-0000-000000000000",
 					},
 					{
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 563250,
+						"price_in_pence": 716850,
 						"space_guid":     "00000001-0002-0000-0000-000000000000",
 					},
 				})
@@ -328,18 +337,20 @@ var _ = Describe("API", func() {
 
 			It("should return resource totals for the given org", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"guid":           "00000001-0001-0001-0000-000000000000",
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 70400,
+						"price_in_pence": 9216000,
 						"space_guid":     "00000001-0001-0000-0000-000000000000",
 					},
 					{
 						"guid":           "00000001-0002-0001-0000-000000000000",
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 563200,
+						"price_in_pence": 716800,
 						"space_guid":     "00000001-0002-0000-0000-000000000000",
 					},
 					{
@@ -361,21 +372,23 @@ var _ = Describe("API", func() {
 
 			It("should return pricing totals for each space", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 70400,
+						"price_in_pence": 9216000,
 						"space_guid":     "00000001-0001-0000-0000-000000000000",
 					},
 					{
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 563250,
+						"price_in_pence": 716850,
 						"space_guid":     "00000001-0002-0000-0000-000000000000",
 					},
 					{
 						"org_guid":       "00000002-0000-0000-0000-000000000000",
-						"price_in_pence": 185900,
+						"price_in_pence": 294700,
 						"space_guid":     "00000002-0001-0000-0000-000000000000",
 					},
 					{
@@ -424,12 +437,14 @@ var _ = Describe("API", func() {
 
 			It("should return resource totals for the given space", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"guid":           "00000001-0001-0001-0000-000000000000",
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 70400,
+						"price_in_pence": 9216000,
 						"space_guid":     "00000001-0001-0000-0000-000000000000",
 					},
 				})
@@ -446,11 +461,13 @@ var _ = Describe("API", func() {
 
 			It("should return space total", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, map[string]interface{}{
 					"space_guid":     guid,
 					"org_guid":       "00000002-0000-0000-0000-000000000000",
-					"price_in_pence": 185900,
+					"price_in_pence": 294700,
 				})
 			})
 
@@ -474,18 +491,20 @@ var _ = Describe("API", func() {
 
 			It("should return totals for each resource", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"guid":           "00000001-0001-0001-0000-000000000000",
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 70400,
+						"price_in_pence": 9216000,
 						"space_guid":     "00000001-0001-0000-0000-000000000000",
 					},
 					{
 						"guid":           "00000001-0002-0001-0000-000000000000",
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 563200,
+						"price_in_pence": 716800,
 						"space_guid":     "00000001-0002-0000-0000-000000000000",
 					},
 					{
@@ -497,13 +516,13 @@ var _ = Describe("API", func() {
 					{
 						"guid":           "00000002-0001-0001-0000-000000000000",
 						"org_guid":       "00000002-0000-0000-0000-000000000000",
-						"price_in_pence": 19200,
+						"price_in_pence": 38400,
 						"space_guid":     "00000002-0001-0000-0000-000000000000",
 					},
 					{
 						"guid":           "00000002-0001-0002-0000-000000000000",
 						"org_guid":       "00000002-0000-0000-0000-000000000000",
-						"price_in_pence": 166400,
+						"price_in_pence": 256000,
 						"space_guid":     "00000002-0001-0000-0000-000000000000",
 					},
 					{
@@ -575,11 +594,13 @@ var _ = Describe("API", func() {
 
 			It("should return totals for each resource", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, map[string]interface{}{
 					"guid":           guid,
 					"org_guid":       "00000002-0000-0000-0000-000000000000",
-					"price_in_pence": 166400,
+					"price_in_pence": 256000,
 					"space_guid":     "00000002-0001-0000-0000-000000000000",
 				})
 			})
@@ -606,15 +627,18 @@ var _ = Describe("API", func() {
 
 			It("should return event details for a resource", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(3)
+				to := now
+				computePlanBoundry := monthsAgo(1)
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"space_guid":        "00000001-0001-0000-0000-000000000000",
 						"pricing_plan_id":   10,
 						"pricing_plan_name": "ComputePlanA",
-						"from":              agoRFC3339(10 * time.Hour),
-						"to":                agoRFC3339(1 * time.Hour),
-						"price_in_pence":    9 * 64 * 1 * 100,
+						"from":              from.Format(time.RFC3339),
+						"to":                computePlanBoundry.Format(time.RFC3339),
+						"price_in_pence":    int(computePlanBoundry.Sub(from).Hours()) * 64 * 1 * 100,
 						"guid":              guid,
 						"org_guid":          "00000001-0000-0000-0000-000000000000",
 					},
@@ -622,9 +646,9 @@ var _ = Describe("API", func() {
 						"space_guid":        "00000001-0001-0000-0000-000000000000",
 						"pricing_plan_id":   11,
 						"pricing_plan_name": "ComputePlanB",
-						"from":              agoRFC3339(1 * time.Hour),
-						"to":                nowRFC3339,
-						"price_in_pence":    1 * 64 * 2 * 100,
+						"from":              computePlanBoundry.Format(time.RFC3339),
+						"to":                to.Format(time.RFC3339),
+						"price_in_pence":    int(to.Sub(computePlanBoundry).Hours()) * 64 * 2 * 100,
 						"guid":              guid,
 						"org_guid":          "00000001-0000-0000-0000-000000000000",
 					},
@@ -633,12 +657,14 @@ var _ = Describe("API", func() {
 
 			It("should only return events for the given range", func() {
 				var out interface{}
-				requestRanged(path, ago(10*time.Hour), ago(9*time.Hour), &out)
+				from := monthsAgo(3)
+				to := monthsAgo(3).Add(1 * time.Hour)
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"space_guid":        "00000001-0001-0000-0000-000000000000",
-						"from":              agoRFC3339(10 * time.Hour),
-						"to":                agoRFC3339(9 * time.Hour),
+						"from":              from.Format(time.RFC3339),
+						"to":                to.Format(time.RFC3339),
 						"price_in_pence":    1 * 64 * 1 * 100,
 						"pricing_plan_id":   10,
 						"pricing_plan_name": "ComputePlanA",
@@ -658,31 +684,33 @@ var _ = Describe("API", func() {
 
 			It("should fetch pricing plans", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"id":         20,
 						"name":       "ServicePlanA",
 						"plan_guid":  "00000000-0000-0000-0000-100000000000",
-						"valid_from": agoRFC3339(100 * time.Hour),
+						"valid_from": monthsAgoRFC3339(3),
 					},
 					{
 						"id":         30,
 						"name":       "ServicePlanB",
 						"plan_guid":  "00000000-0000-0000-0000-200000000000",
-						"valid_from": agoRFC3339(100 * time.Hour),
+						"valid_from": monthsAgoRFC3339(3),
 					},
 					{
 						"id":         10,
 						"name":       "ComputePlanA",
 						"plan_guid":  db.ComputePlanGuid,
-						"valid_from": agoRFC3339(100 * time.Hour),
+						"valid_from": monthsAgoRFC3339(3),
 					},
 					{
 						"id":         11,
 						"name":       "ComputePlanB",
 						"plan_guid":  db.ComputePlanGuid,
-						"valid_from": agoRFC3339(1 * time.Hour),
+						"valid_from": monthsAgoRFC3339(1),
 					},
 				})
 			})
@@ -698,12 +726,14 @@ var _ = Describe("API", func() {
 
 			It("should fetch pricing plan by id", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, map[string]interface{}{
 					"id":         id,
 					"name":       "ServicePlanB",
 					"plan_guid":  "00000000-0000-0000-0000-200000000000",
-					"valid_from": agoRFC3339(100 * time.Hour),
+					"valid_from": monthsAgoRFC3339(3),
 				})
 			})
 		})
@@ -830,22 +860,24 @@ var _ = Describe("API", func() {
 
 			It("should let admin see ALL spaces", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 70400,
+						"price_in_pence": 9216000,
 						"space_guid":     "00000001-0001-0000-0000-000000000000",
 					},
 					{
 						"org_guid":       "00000001-0000-0000-0000-000000000000",
-						"price_in_pence": 563250,
+						"price_in_pence": 716850,
 						"space_guid":     "00000001-0002-0000-0000-000000000000",
 					},
 
 					{
 						"org_guid":       "00000002-0000-0000-0000-000000000000",
-						"price_in_pence": 185900,
+						"price_in_pence": 294700,
 						"space_guid":     "00000002-0001-0000-0000-000000000000",
 					},
 					{
@@ -855,7 +887,7 @@ var _ = Describe("API", func() {
 					},
 					{
 						"org_guid":       "00000002-0000-0000-0000-000000000000",
-						"price_in_pence": 1050,
+						"price_in_pence": 1850,
 						"space_guid":     "00000002-0003-0000-0000-000000000000",
 					},
 				})
@@ -871,31 +903,33 @@ var _ = Describe("API", func() {
 
 			It("should fetch pricing plans", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, []map[string]interface{}{
 					{
 						"id":         20,
 						"name":       "ServicePlanA",
 						"plan_guid":  "00000000-0000-0000-0000-100000000000",
-						"valid_from": agoRFC3339(100 * time.Hour),
+						"valid_from": monthsAgoRFC3339(3),
 					},
 					{
 						"id":         30,
 						"name":       "ServicePlanB",
 						"plan_guid":  "00000000-0000-0000-0000-200000000000",
-						"valid_from": agoRFC3339(100 * time.Hour),
+						"valid_from": monthsAgoRFC3339(3),
 					},
 					{
 						"id":         10,
 						"name":       "ComputePlanA",
 						"plan_guid":  db.ComputePlanGuid,
-						"valid_from": agoRFC3339(100 * time.Hour),
+						"valid_from": monthsAgoRFC3339(3),
 					},
 					{
 						"id":         11,
 						"name":       "ComputePlanB",
 						"plan_guid":  db.ComputePlanGuid,
-						"valid_from": agoRFC3339(1 * time.Hour),
+						"valid_from": monthsAgoRFC3339(1),
 					},
 				})
 			})
@@ -911,12 +945,14 @@ var _ = Describe("API", func() {
 
 			It("should fetch pricing plan by id", func() {
 				var out interface{}
-				request(path, &out)
+				from := monthsAgo(1)
+				to := now
+				requestRanged(path, from, to, &out)
 				ExpectJSON(out, map[string]interface{}{
 					"id":         id,
 					"name":       "ServicePlanB",
 					"plan_guid":  "00000000-0000-0000-0000-200000000000",
-					"valid_from": agoRFC3339(100 * time.Hour),
+					"valid_from": monthsAgoRFC3339(3),
 				})
 			})
 		})
@@ -932,16 +968,17 @@ var _ = Describe("API", func() {
 			)
 
 			It("should create a pricing plan (form POST)", func() {
+				newValidFrom := monthsAgoRFC3339(4)
 				form := url.Values{}
 				form.Add("name", "NewPlan")
-				form.Add("valid_from", agoRFC3339(1*time.Minute))
+				form.Add("valid_from", newValidFrom)
 				form.Add("plan_guid", "aaaaaaa-bbbb-cccc-ddddddddddddd")
 				status, out := post(path, strings.NewReader(form.Encode()))
 				Expect(status).To(Equal(http.StatusOK))
 				ExpectJSON(out, map[string]interface{}{
 					"id":         1,
 					"name":       "NewPlan",
-					"valid_from": agoRFC3339(1 * time.Minute),
+					"valid_from": newValidFrom,
 					"plan_guid":  "aaaaaaa-bbbb-cccc-ddddddddddddd",
 				})
 			})
@@ -955,9 +992,10 @@ var _ = Describe("API", func() {
 			)
 
 			It("should update a pricing plan (via form PUT)", func() {
+				newValidFrom := monthsAgoRFC3339(5)
 				form := url.Values{}
 				form.Add("name", "UpdatedPlan")
-				form.Add("valid_from", agoRFC3339(111*time.Hour))
+				form.Add("valid_from", newValidFrom)
 				form.Add("plan_guid", db.ComputePlanGuid)
 				status, out := put(path, strings.NewReader(form.Encode()))
 				Expect(status).To(Equal(http.StatusOK))
@@ -965,7 +1003,7 @@ var _ = Describe("API", func() {
 					"id":         11,
 					"name":       "UpdatedPlan",
 					"plan_guid":  db.ComputePlanGuid,
-					"valid_from": agoRFC3339(111 * time.Hour),
+					"valid_from": newValidFrom,
 				})
 			})
 		})
@@ -985,7 +1023,7 @@ var _ = Describe("API", func() {
 					"id":         11,
 					"name":       "ComputePlanB",
 					"plan_guid":  db.ComputePlanGuid,
-					"valid_from": agoRFC3339(1 * time.Hour),
+					"valid_from": monthsAgoRFC3339(1),
 				})
 			})
 		})

--- a/api/resource_usage_test.go
+++ b/api/resource_usage_test.go
@@ -982,6 +982,20 @@ var _ = Describe("API", func() {
 					"plan_guid":  "aaaaaaa-bbbb-cccc-ddddddddddddd",
 				})
 			})
+
+			It("should not create a pricing plan that violates valid_from constraint (form POST)", func() {
+				invalidFrom := "2017-04-04T00:00:00Z"
+				form := url.Values{}
+				form.Add("name", "NewPlan")
+				form.Add("valid_from", invalidFrom)
+				form.Add("plan_guid", "aaaaaaa-bbbb-cccc-ddddddddddddd")
+				status, out := post(path, strings.NewReader(form.Encode()))
+				Expect(status).To(Equal(http.StatusBadRequest))
+				ExpectJSON(out, map[string]interface{}{
+					"error":      "constraint violation",
+					"constraint": "valid_from_start_of_month",
+				})
+			})
 		})
 
 		Context("/pricing_plans/:id", func() {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Db", func() {
 			_, err := sqlClient.Conn.Exec(`
 				insert into pricing_plans(name, valid_from, plan_guid) values (
 					'FormulaTestPlan',
-					'-infinity',
+					'2000-01-01',
 					$1
 				);
 			`, uuid.NewV4().String())

--- a/db/sql/037_add_valid_from_first_day_of_month_constraint_to_pricing_plans.sql
+++ b/db/sql/037_add_valid_from_first_day_of_month_constraint_to_pricing_plans.sql
@@ -1,0 +1,7 @@
+ALTER TABLE pricing_plans DROP CONSTRAINT IF EXISTS valid_from_start_of_month;
+ALTER TABLE pricing_plans ADD CONSTRAINT valid_from_start_of_month CHECK (
+  (extract (day from valid_from)) = 1 AND
+  (extract (hour from valid_from)) = 0 AND
+  (extract (minute from valid_from)) = 0 AND
+  (extract (second from valid_from)) = 0
+);

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sort"
 	"time"
@@ -88,7 +89,7 @@ func errorHandler(err error, c echo.Context) {
 	switch v := err.(type) {
 	case *echo.HTTPError:
 		code = v.Code
-		resp.Error = v.Error()
+		resp.Error = fmt.Sprintf("%s", v.Message)
 	case *pq.Error:
 		if v.Code.Name() == "check_violation" {
 			code = http.StatusBadRequest

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -1,0 +1,13 @@
+package server_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server Suite")
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,86 @@
+package server_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/alphagov/paas-billing/auth"
+	"github.com/alphagov/paas-billing/server"
+	"github.com/labstack/echo"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type SimpleAuthenticator struct{}
+
+func (sa *SimpleAuthenticator) Authorize(c echo.Context) error {
+	return fmt.Errorf("unauthorized-in-test")
+}
+
+func (sa *SimpleAuthenticator) Exchange(c echo.Context) error {
+	return fmt.Errorf("unauthorized-in-test")
+}
+
+func (sa *SimpleAuthenticator) NewAuthorizer(token string) (auth.Authorizer, error) {
+	return nil, fmt.Errorf("not-authorizor-in-test")
+}
+
+var _ = Describe("Server", func() {
+
+	It("should catch panics and turn them into 'internal server error' json errors", func() {
+		e := server.New(nil, &SimpleAuthenticator{}, nil)
+		e.GET("/panic", func(c echo.Context) error {
+			panic("bang")
+			return c.JSON(http.StatusOK, nil)
+		})
+		req := httptest.NewRequest(echo.GET, "/panic", nil)
+		res := httptest.NewRecorder()
+		e.ServeHTTP(res, req)
+		Expect(res.Code).To(Equal(500))
+		Expect(res.Header().Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
+		Expect(res.Body.String()).To(Equal(`{"error":"internal server error"}`))
+	})
+
+	It("should return 'internal server error' for unknown errors", func() {
+		e := server.New(nil, &SimpleAuthenticator{}, nil)
+		e.GET("/error", func(c echo.Context) error {
+			return fmt.Errorf("this-error-leaks-sensitive-info")
+		})
+		req := httptest.NewRequest(echo.GET, "/error", nil)
+		res := httptest.NewRecorder()
+		e.ServeHTTP(res, req)
+		Expect(res.Code).To(Equal(500))
+		Expect(res.Header().Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
+		Expect(res.Body.String()).To(Equal(`{"error":"internal server error"}`))
+	})
+
+	It("should pass-through errors of type echo.HTTPError (with message type string)", func() {
+		e := server.New(nil, &SimpleAuthenticator{}, nil)
+		e.GET("/expected-error", func(c echo.Context) error {
+			return echo.NewHTTPError(http.StatusTeapot, "friendly-string-message")
+		})
+		req := httptest.NewRequest(echo.GET, "/expected-error", nil)
+		res := httptest.NewRecorder()
+		e.ServeHTTP(res, req)
+		Expect(res.Code).To(Equal(http.StatusTeapot))
+		Expect(res.Header().Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
+		Expect(res.Body.String()).To(Equal(`{"error":"friendly-string-message"}`))
+	})
+
+	It("should pass-through errors of type echo.HTTPError (with message type error)", func() {
+		e := server.New(nil, &SimpleAuthenticator{}, nil)
+		e.GET("/expected-error", func(c echo.Context) error {
+			return echo.NewHTTPError(http.StatusTeapot, errors.New("friendly-error-message"))
+		})
+		req := httptest.NewRequest(echo.GET, "/expected-error", nil)
+		res := httptest.NewRecorder()
+		e.ServeHTTP(res, req)
+		Expect(res.Code).To(Equal(http.StatusTeapot))
+		Expect(res.Header().Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
+		Expect(res.Body.String()).To(Equal(`{"error":"friendly-error-message"}`))
+	})
+
+})


### PR DESCRIPTION
## What

A constraint has been added that requires all pricing_plans to have a valid_from date that lands on the 1st of a month.

This is to avoid situations where the display of monthly statements might be hard to understand.

We also refactored tests to accomodate the change.

## How to review

Code review and ensuring the tests run ok. 

## Who can review

Not @chrisfarms, @46bit, @dcarley 
