### PR TITLE
[#156224091] Stop pulling bearer token from cookie header

### DIFF
--- a/eventserver/auth/middleware.go
+++ b/eventserver/auth/middleware.go
@@ -7,10 +7,6 @@ import (
 	"github.com/labstack/echo"
 )
 
-const (
-	CookieAuthorization = "authorization"
-)
-
 func GetTokenFromRequest(c echo.Context) (string, error) {
 	if t := c.Request().Header.Get(echo.HeaderAuthorization); t != "" {
 		parts := strings.Split(t, " ")
@@ -24,8 +20,6 @@ func GetTokenFromRequest(c echo.Context) (string, error) {
 			return "", errors.New("missing Authorization Bearer token data")
 		}
 		return parts[1], nil
-	} else if cookie, err := c.Cookie(CookieAuthorization); err == nil && cookie.Value != "" {
-		return cookie.Value, nil
 	}
 	return "", errors.New("no access_token in request")
 }


### PR DESCRIPTION
## What

The eventserver no longer exposes a browser UI and as a result we no longer need to support passing tokens around in cookies.

This removes grabbing tokens from the Cookie header. It is now only valid to pass a token in the Authorization header.

## How to review

I suspect code review and running the tests should be sufficient.

## Who can review

not @chrisfarms
