### PR TITLE
[#156753589] Add tasks to the billable events

### DIFF
--- a/config.json
+++ b/config.json
@@ -89,6 +89,25 @@
 			]
 		},
 		{
+			"name": "task",
+			"valid_from": "2017-01-01",
+			"plan_guid": "ebfa9453-ef66-450c-8c37-d53dfd931038",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "platform",
+					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "postgres micro",
 			"valid_from": "2017-01-01",
 			"plan_guid": "e264800e-20cb-4bf0-99fc-84bd42681d81",

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -66,6 +66,30 @@ INSERT INTO events with
 			where
 				raw_message->>'service_instance_type' = 'managed_service_instance'
 				and raw_message->>'space_name' !~ '^(SMOKE|ACC|CATS|PERF)-' -- FIXME: this is open to abuse
+		) union all (
+			select
+				id as event_sequence,
+				guid::uuid as event_guid,
+				created_at,
+				(raw_message->>'task_guid')::uuid as resource_guid,
+				(raw_message->>'task_name') as resource_name,
+				'task'::text as resource_type,                              -- resource_type for task resources
+				(raw_message->>'org_guid')::uuid as org_guid,
+				(raw_message->>'space_guid')::uuid as space_guid,
+				'ebfa9453-ef66-450c-8c37-d53dfd931038'::uuid as plan_guid,  -- plan guid for all task resources
+				'task'::text as plan_name,                                  -- plan name for all task resources
+				coalesce(raw_message->>'instance_count', '1')::numeric as number_of_nodes,
+				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::numeric as memory_in_mb,
+				'0'::numeric as storage_in_mb,
+				(case
+					when (raw_message->>'state') = 'TASK_STARTED' then 'STARTED'
+					when (raw_message->>'state') = 'TASK_STOPPED' then 'STOPPED'
+				end)::resource_state as state
+			from
+				app_usage_events
+			where
+				(raw_message->>'state' = 'TASK_STARTED' or raw_message->>'state' = 'TASK_STOPPED')
+				and raw_message->>'space_name' !~ '^(SMOKE|ACC|CATS|PERF)-' -- FIXME: this is open to abuse
 		)
 	),
 	event_ranges as (

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -21,6 +21,7 @@ const (
 	AppUsageTableName     = "app_usage_events"
 	ServiceUsageTableName = "service_usage_events"
 	ComputePlanGUID       = "f4d4b95a-f55e-4593-8d54-3364c25798c4"
+	TaskPlanGUID          = "ebfa9453-ef66-450c-8c37-d53dfd931038"
 	DefaultInitTimeout    = 5 * time.Minute
 	DefaultRefreshTimeout = 5 * time.Minute
 	DefaultStoreTimeout   = 45 * time.Second


### PR DESCRIPTION
## What

Currently, the tasks are being ignored when it comes to converting data
into our defined standard. Tasks too cost money, therefore we'd like to
make sure those are standardised and counted towards any billing
calculations.

## How to review

- Run tests
- Run application against your environment
- Create and kill a task
- Request and see data (tested myself)
