### PR TITLE
[#157287692] /pricing_plans endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 	* [GET /usage_events](#get-usage_events)
 	* [GET /billable_events](#get-billable_events)
 	* [GET /forecast_events](#get-forecast_events)
+	* [GET /pricing_plans](#get-pricing_plans)
 * [Development](#development)
 	* [Create a temporary Postgres server](#create-a-temporary-postgres-server)
 	* [Run the application](#run-the-application)
@@ -395,6 +396,67 @@ curl -s -G 'http://localhost:8881/forecast_events' \
 				},
 			},
 		}
+	}
+	...
+]
+```
+
+### `GET /pricing_plans`
+
+PricingPlans define how the costs for resources are applied. The PricingPlans are setup in the configuraiton json file. Each UsageEvent's PlanGUID should have a matching PricingPlan for a given point in time.
+
+Each PricingPlan may be made up of multiple PricingComponents (for example a database service may have components for the CPU/VM instance and also for the storage used).
+
+You can fetch the available PricingPlans for a given time period to see what resources are available and how the costs are calculated.
+
+**Authorization:**
+
+Authorization is not required for this endpoint.
+
+**Query parameters:**
+
+| Name | Type | Example | Notes |
+|---|---|---|---|
+| range_start | timestamp | 2001-01-01 | **required** start of period to query |
+| range_stop | timestamp | 2017-01-01 | **required** end of period to query |
+
+**Example:**
+
+```
+RANGE_START="2018-01-01"
+RANGE_STOP="2018-02-01"
+
+curl -s -G 'http://localhost:8881/pricing_plans' \
+	--data-urlencode "range_start=${RANGE_START}" \
+	--data-urlencode "range_stop=${RANGE_STOP}"
+```
+
+**Returns:**
+
+```javascript
+[
+	...
+	{
+		"name": "PLAN2",
+		"plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+		"valid_from": "2002-01-01",
+		"components": [
+			{
+				"name": "cpu-usage",
+				"formula": "$number_of_nodes * 0.001 * $time_in_seconds",
+				"vat_code": "Standard",
+				"currency_code": "GBP"
+			},
+			{
+				"name": "storage-usage",
+				"formula": "$storage_in_mb * 0.0001 * $time_in_seconds",
+				"vat_code": "Standard",
+				"currency_code": "GBP"
+			}
+		],
+		"memory_in_mb": 264,
+		"storage_in_mb": 265,
+		"number_of_nodes": 2
 	}
 	...
 ]

--- a/eventio/event_config.go
+++ b/eventio/event_config.go
@@ -1,0 +1,30 @@
+package eventio
+
+type PricingPlan struct {
+	Name          string                 `json:"name"`
+	PlanGUID      string                 `json:"plan_guid"`
+	ValidFrom     string                 `json:"valid_from"`
+	Components    []PricingPlanComponent `json:"components"`
+	MemoryInMB    uint                   `json:"memory_in_mb"`
+	StorageInMB   uint                   `json:"storage_in_mb"`
+	NumberOfNodes uint                   `json:"number_of_nodes"`
+}
+
+type PricingPlanComponent struct {
+	Name         string `json:"name"`
+	Formula      string `json:"formula"`
+	VATCode      string `json:"vat_code"`
+	CurrencyCode string `json:"currency_code"`
+}
+
+type VATRate struct {
+	Code      string  `json:"code"`
+	ValidFrom string  `json:"valid_from"`
+	Rate      float64 `json:"rate"`
+}
+
+type CurrencyRate struct {
+	Code      string  `json:"code"`
+	ValidFrom string  `json:"valid_from"`
+	Rate      float64 `json:"rate"`
+}

--- a/eventio/event_filter.go
+++ b/eventio/event_filter.go
@@ -1,6 +1,8 @@
 package eventio
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type EventFilter struct {
 	RangeStart string
@@ -9,6 +11,21 @@ type EventFilter struct {
 }
 
 func (filter *EventFilter) Validate() error {
+	if filter.RangeStart == "" {
+		return fmt.Errorf(`a range start filter value is required`)
+	}
+	if filter.RangeStop == "" {
+		return fmt.Errorf(`a range stop filter value is required`)
+	}
+	return nil
+}
+
+type PricingPlanFilter struct {
+	RangeStart string
+	RangeStop  string
+}
+
+func (filter *PricingPlanFilter) Validate() error {
 	if filter.RangeStart == "" {
 		return fmt.Errorf(`a range start filter value is required`)
 	}

--- a/eventio/event_store.go
+++ b/eventio/event_store.go
@@ -8,9 +8,14 @@ type RawEventReader interface {
 	GetEvents(filter RawEventFilter) ([]RawEvent, error)
 }
 
+type PricingPlanReader interface {
+	GetPricingPlans(filter PricingPlanFilter) ([]PricingPlan, error)
+}
+
 type EventStore interface {
 	Init() error
 	Refresh() error
+	PricingPlanReader
 	RawEventWriter
 	RawEventReader
 	UsageEventReader

--- a/eventserver/server.go
+++ b/eventserver/server.go
@@ -37,6 +37,7 @@ func New(cfg Config) *echo.Echo {
 		e.Logger = NewLogger(cfg.Logger)
 	}
 
+	e.GET("/pricing_plans", PricingPlansHandler(cfg.Store))
 	e.GET("/forecast_events", ForecastEventsHandler(cfg.Store))
 	e.GET("/usage_events", UsageEventsHandler(cfg.Store, cfg.Authenticator))
 	e.GET("/billable_events", BillableEventsHandler(cfg.Store, cfg.Authenticator))

--- a/eventserver/server_plans_handler.go
+++ b/eventserver/server_plans_handler.go
@@ -1,0 +1,23 @@
+package eventserver
+
+import (
+	"net/http"
+
+	"github.com/alphagov/paas-billing/eventio"
+	"github.com/labstack/echo"
+)
+
+func PricingPlansHandler(store eventio.PricingPlanReader) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		filter := eventio.PricingPlanFilter{
+			RangeStart: c.QueryParam("range_start"),
+			RangeStop:  c.QueryParam("range_stop"),
+		}
+		plans, err := store.GetPricingPlans(filter)
+		if err != nil {
+			return err
+		}
+		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+		return c.JSON(http.StatusOK, plans)
+	}
+}

--- a/eventserver/server_plans_handler_test.go
+++ b/eventserver/server_plans_handler_test.go
@@ -1,0 +1,158 @@
+package eventserver_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/alphagov/paas-billing/eventio"
+	"github.com/alphagov/paas-billing/eventstore"
+	"github.com/alphagov/paas-billing/fakes"
+	"github.com/labstack/echo"
+
+	. "github.com/alphagov/paas-billing/eventserver"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PricingPlansHandler", func() {
+
+	var (
+		ctx               context.Context
+		cancel            context.CancelFunc
+		cfg               Config
+		fakeAuthenticator *fakes.FakeAuthenticator
+		fakeAuthorizer    *fakes.FakeAuthorizer
+		fakeStore         *fakes.FakeEventStore
+		token             = "ACCESS_GRANTED_TOKEN"
+	)
+
+	BeforeEach(func() {
+		fakeStore = &fakes.FakeEventStore{}
+		fakeAuthenticator = &fakes.FakeAuthenticator{}
+		fakeAuthorizer = &fakes.FakeAuthorizer{}
+		cfg = Config{
+			Authenticator: fakeAuthenticator,
+			Logger:        lager.NewLogger("test"),
+			Store:         fakeStore,
+			EnablePanic:   true,
+		}
+		ctx, cancel = context.WithCancel(context.Background())
+		fakeAuthenticator.NewAuthorizerReturns(fakeAuthorizer, nil)
+		fakeAuthorizer.AdminReturns(false, nil)
+	})
+
+	AfterEach(func() {
+		defer cancel()
+	})
+
+	It("should request the plans from the store and return json", func() {
+		fakeStore.GetPricingPlansReturns([]eventio.PricingPlan{
+			{
+				PlanGUID:      eventstore.ComputePlanGUID,
+				ValidFrom:     "2001-01-01",
+				Name:          "PLAN1",
+				MemoryInMB:    164,
+				StorageInMB:   165,
+				NumberOfNodes: 1,
+				Components: []eventio.PricingPlanComponent{
+					{
+						Name:         "PLAN1COMPONENT1",
+						Formula:      "1111 * 1",
+						CurrencyCode: "GBP",
+						VATCode:      "Standard",
+					},
+				},
+			},
+			{
+				PlanGUID:      eventstore.ComputePlanGUID,
+				ValidFrom:     "2002-01-01",
+				Name:          "PLAN2",
+				MemoryInMB:    264,
+				StorageInMB:   265,
+				NumberOfNodes: 2,
+				Components: []eventio.PricingPlanComponent{
+					{
+						Name:         "PLAN2COMPONENT1",
+						Formula:      "2222 * 1",
+						CurrencyCode: "GBP",
+						VATCode:      "Standard",
+					},
+					{
+						Name:         "PLAN2COMPONENT2",
+						Formula:      "2222 * 2",
+						CurrencyCode: "GBP",
+						VATCode:      "Standard",
+					},
+				},
+			},
+		}, nil)
+		rangeStart := "2001-01-01"
+		rangeStop := "2002-02-02"
+
+		u := url.URL{}
+		u.Path = "/pricing_plans"
+		q := u.Query()
+		q.Set("range_start", rangeStart)
+		q.Set("range_stop", rangeStop)
+		u.RawQuery = q.Encode()
+		req := httptest.NewRequest(echo.GET, u.String(), nil)
+		req.Header.Set("Authorization", "bearer "+token)
+		res := httptest.NewRecorder()
+
+		e := New(cfg)
+		e.ServeHTTP(res, req)
+		defer e.Shutdown(ctx)
+
+		Expect(fakeStore.GetPricingPlansCallCount()).To(Equal(1))
+
+		filter := fakeStore.GetPricingPlansArgsForCall(0)
+		Expect(filter.RangeStart).To(Equal(rangeStart))
+		Expect(filter.RangeStop).To(Equal(rangeStop))
+
+		Expect(res.Body).To(MatchJSON(`[
+			{
+				"name": "PLAN1",
+				"plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+				"valid_from": "2001-01-01",
+				"components": [
+					{
+						"name": "PLAN1COMPONENT1",
+						"formula": "1111 * 1",
+						"vat_code": "Standard",
+						"currency_code": "GBP"
+					}
+				],
+				"memory_in_mb": 164,
+				"storage_in_mb": 165,
+				"number_of_nodes": 1
+			},
+			{
+				"name": "PLAN2",
+				"plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+				"valid_from": "2002-01-01",
+				"components": [
+					{
+						"name": "PLAN2COMPONENT1",
+						"formula": "2222 * 1",
+						"vat_code": "Standard",
+						"currency_code": "GBP"
+					},
+					{
+						"name": "PLAN2COMPONENT2",
+						"formula": "2222 * 2",
+						"vat_code": "Standard",
+						"currency_code": "GBP"
+					}
+				],
+				"memory_in_mb": 264,
+				"storage_in_mb": 265,
+				"number_of_nodes": 2
+			}
+		]`))
+		Expect(res.Code).To(Equal(200))
+		Expect(res.Header().Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
+	})
+
+})

--- a/eventstore/store_billable_events_test.go
+++ b/eventstore/store_billable_events_test.go
@@ -34,11 +34,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	*-----------------------------------------------------------------------------------*/
 	It("Should return one BillingEvent for an app that was running for 1hr", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -123,11 +123,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	*-----------------------------------------------------------------------------------*/
 	It("Should return one BillingEvent for a task that was running for 1hr", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.TaskPlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "task",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -211,11 +211,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	-------------------------------------------------------------------------------------*/
 	It("Should return two BillingEvent that represent a scaling", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -337,11 +337,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	-------------------------------------------------------------------------------------*/
 	It("should return a BillableEvent for an app without a stop event yet", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -398,11 +398,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .       |__________requested range__________|   .   .   .   .   .   .
 	-------------------------------------------------------------------------------------*/
 	It("should return a BillableEvent with duration cropped to the requeted range", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -455,11 +455,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	----------------------------------------------------------------------------------------*/
 	It("should return one BillingEvent with two pricing components when intersects two plans", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2017-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "1",
@@ -468,11 +468,11 @@ var _ = Describe("GetBillableEvents", func() {
 				},
 			},
 		})
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2017-02-01",
 			Name:      "PLAN2",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "33",
@@ -562,11 +562,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	----------------------------------------------------------------------------------------*/
 	It("should return a single BillingEvent with two pricing components when a single event intersects two VAT rates", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2017-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "1",
@@ -575,7 +575,7 @@ var _ = Describe("GetBillableEvents", func() {
 				},
 			},
 		})
-		cfg.AddVATRate(eventstore.VATRate{
+		cfg.AddVATRate(eventio.VATRate{
 			Code:      "Standard",
 			Rate:      0,
 			ValidFrom: "2017-02-01",
@@ -661,11 +661,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	----------------------------------------------------------------------------------------*/
 	It("should return a single BillingEvent with two pricing components when the event intersects two CurrencyRates", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2017-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "1",
@@ -674,7 +674,7 @@ var _ = Describe("GetBillableEvents", func() {
 				},
 			},
 		})
-		cfg.AddCurrencyRate(eventstore.CurrencyRate{
+		cfg.AddCurrencyRate(eventio.CurrencyRate{
 			Code:      "GBP",
 			Rate:      2,
 			ValidFrom: "2017-02-01",
@@ -765,11 +765,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   |   .  component1.  . | component2 |  component3  |    component4    .  |   .   .
 	----------------------------------------------------------------------------------------*/
 	It("should return a single BillingEvent with four pricing components when the events intersects currency and vate rate changes", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2017-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "1",
@@ -778,17 +778,17 @@ var _ = Describe("GetBillableEvents", func() {
 				},
 			},
 		})
-		cfg.AddVATRate(eventstore.VATRate{
+		cfg.AddVATRate(eventio.VATRate{
 			Code:      "Standard",
 			Rate:      0,
 			ValidFrom: "2017-03-01",
 		})
-		cfg.AddCurrencyRate(eventstore.CurrencyRate{
+		cfg.AddCurrencyRate(eventio.CurrencyRate{
 			Code:      "GBP",
 			Rate:      2,
 			ValidFrom: "2017-02-01",
 		})
-		cfg.AddCurrencyRate(eventstore.CurrencyRate{
+		cfg.AddCurrencyRate(eventio.CurrencyRate{
 			Code:      "GBP",
 			Rate:      4,
 			ValidFrom: "2017-04-01",
@@ -899,11 +899,11 @@ var _ = Describe("GetBillableEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	*-----------------------------------------------------------------------------------*/
 	It("Should round price of BillingEvent to a 1p if it is less than that", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "0.0000000001",

--- a/eventstore/store_config.go
+++ b/eventstore/store_config.go
@@ -1,49 +1,99 @@
 package eventstore
 
-type PricingPlan struct {
-	Name          string                 `json:"name"`
-	PlanGUID      string                 `json:"plan_guid"`
-	ValidFrom     string                 `json:"valid_from"`
-	Components    []PricingPlanComponent `json:"components"`
-	MemoryInMB    uint                   `json:"memory_in_mb"`
-	StorageInMB   uint                   `json:"storage_in_mb"`
-	NumberOfNodes uint                   `json:"number_of_nodes"`
-}
+import (
+	"encoding/json"
 
-type PricingPlanComponent struct {
-	Name         string `json:"name"`
-	Formula      string `json:"formula"`
-	VATCode      string `json:"vat_code"`
-	CurrencyCode string `json:"currency_code"`
-}
-
-type VATRate struct {
-	Code      string  `json:"code"`
-	ValidFrom string  `json:"valid_from"`
-	Rate      float64 `json:"rate"`
-}
-
-type CurrencyRate struct {
-	Code      string  `json:"code"`
-	ValidFrom string  `json:"valid_from"`
-	Rate      float64 `json:"rate"`
-}
+	"github.com/alphagov/paas-billing/eventio"
+)
 
 type Config struct {
-	VATRates           []VATRate      `json:"vat_rates"`            // vat rate
-	CurrencyRates      []CurrencyRate `json:"currency_rates"`       // exchange rates
-	PricingPlans       []PricingPlan  `json:"pricing_plans"`        // dataset to generate prices from
-	IgnoreMissingPlans bool           `json:"ignore_missing_plans"` // if true, will generate missing plans that emit "£0", useful for testing
+	VATRates           []eventio.VATRate      `json:"vat_rates"`            // vat rate
+	CurrencyRates      []eventio.CurrencyRate `json:"currency_rates"`       // exchange rates
+	PricingPlans       []eventio.PricingPlan  `json:"pricing_plans"`        // dataset to generate prices from
+	IgnoreMissingPlans bool                   `json:"ignore_missing_plans"` // if true, will generate missing plans that emit "£0", useful for testing
 }
 
-func (cfg *Config) AddPlan(p PricingPlan) {
+func (cfg *Config) AddPlan(p eventio.PricingPlan) {
 	cfg.PricingPlans = append(cfg.PricingPlans, p)
 }
 
-func (cfg *Config) AddVATRate(v VATRate) {
+func (cfg *Config) AddVATRate(v eventio.VATRate) {
 	cfg.VATRates = append(cfg.VATRates, v)
 }
 
-func (cfg *Config) AddCurrencyRate(c CurrencyRate) {
+func (cfg *Config) AddCurrencyRate(c eventio.CurrencyRate) {
 	cfg.CurrencyRates = append(cfg.CurrencyRates, c)
+}
+
+var _ eventio.PricingPlanReader = &EventStore{}
+
+func (s *EventStore) GetPricingPlans(filter eventio.PricingPlanFilter) ([]eventio.PricingPlan, error) {
+	if err := filter.Validate(); err != nil {
+		return nil, err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	rows, err := s.queryJSON(tx, `
+		with
+		valid_pricing_plans as (
+			select
+				*,
+				tstzrange(valid_from, lead(valid_from, 1, 'infinity') over (
+					partition by plan_guid order by valid_from rows between current row and 1 following
+				)) as valid_for
+			from
+				pricing_plans
+		)
+		select
+			vpp.plan_guid,
+			vpp.valid_from,
+			vpp.name,
+			vpp.memory_in_mb,
+			vpp.number_of_nodes,
+			vpp.storage_in_mb,
+			json_agg(json_build_object(
+				'plan_guid', ppc.plan_guid::text,
+				'name', ppc.name,
+				'formula', ppc.formula,
+				'vat_code', ppc.vat_code,
+				'currency_code', ppc.currency_code
+			)) as components
+		from
+			valid_pricing_plans vpp
+		left join
+			pricing_plan_components ppc on ppc.plan_guid = vpp.plan_guid
+			and ppc.valid_from = vpp.valid_from
+		where
+			vpp.valid_for && tstzrange($1, $2)
+		group by
+			vpp.plan_guid,
+			vpp.valid_from,
+			vpp.name,
+			vpp.memory_in_mb,
+			vpp.number_of_nodes,
+			vpp.storage_in_mb
+		order by
+			valid_from
+	`, filter.RangeStart, filter.RangeStop)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	plans := []eventio.PricingPlan{}
+	for rows.Next() {
+		var b []byte
+		if err := rows.Scan(&b); err != nil {
+			return nil, err
+		}
+		var plan eventio.PricingPlan
+		if err := json.Unmarshal(b, &plan); err != nil {
+			return nil, err
+		}
+		plans = append(plans, plan)
+
+	}
+	return plans, nil
 }

--- a/eventstore/store_config_test.go
+++ b/eventstore/store_config_test.go
@@ -1,0 +1,92 @@
+package eventstore_test
+
+import (
+	"github.com/alphagov/paas-billing/eventio"
+	"github.com/alphagov/paas-billing/eventstore"
+	"github.com/alphagov/paas-billing/testenv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetPricingPlans", func() {
+
+	var (
+		cfg eventstore.Config
+	)
+
+	It("should return all the configured plans", func() {
+		cfg = eventstore.Config{
+			VATRates: []eventio.VATRate{
+				{
+					Code:      "Standard",
+					Rate:      0.2,
+					ValidFrom: "epoch",
+				},
+			},
+			CurrencyRates: []eventio.CurrencyRate{
+				{
+					Code:      "GBP",
+					Rate:      1,
+					ValidFrom: "epoch",
+				},
+			},
+			PricingPlans: []eventio.PricingPlan{
+				{
+					PlanGUID:  eventstore.ComputePlanGUID,
+					ValidFrom: "2001-01-01T00:00:00+00:00",
+					Name:      "PLAN1",
+					Components: []eventio.PricingPlanComponent{
+						{
+							Name:         "PLAN1COMPONENT1",
+							Formula:      "1111 * 1",
+							CurrencyCode: "GBP",
+							VATCode:      "Standard",
+						},
+					},
+				},
+				{
+					PlanGUID:      eventstore.ComputePlanGUID,
+					ValidFrom:     "2002-02-01T00:00:00+00:00",
+					Name:          "PLAN2",
+					NumberOfNodes: 2,
+					MemoryInMB:    64,
+					StorageInMB:   1024,
+					Components: []eventio.PricingPlanComponent{
+						{
+							Name:         "PLAN2COMPONENT1",
+							Formula:      "2222 * 1",
+							CurrencyCode: "GBP",
+							VATCode:      "Standard",
+						},
+						{
+							Name:         "PLAN2COMPONENT2",
+							Formula:      "2222 * 2",
+							CurrencyCode: "GBP",
+							VATCode:      "Standard",
+						},
+					},
+				},
+			},
+		}
+
+		env, err := testenv.Open(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		defer env.Close()
+		store := env.Schema
+
+		Expect(store.Refresh()).To(Succeed())
+
+		plans, err := store.GetPricingPlans(eventio.PricingPlanFilter{
+			RangeStart: "2001-01-01",
+			RangeStop:  "2018-01-01",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(plans)).To(BeNumerically("==", 2), "expected two plans to be returned")
+
+		Expect(plans[0]).To(Equal(cfg.PricingPlans[0]), "expected first returned plan to match PLAN1 data")
+		Expect(plans[1]).To(Equal(cfg.PricingPlans[1]), "expected second returned plan to match PLAN2 data")
+	})
+
+})

--- a/eventstore/store_currency_test.go
+++ b/eventstore/store_currency_test.go
@@ -41,26 +41,26 @@ var _ = Describe("Currency Conversion", func() {
 	----------------------------------------------------------------------------------------*/
 	It("should not affect price when using a GBP rate of 1", func() {
 		cfg = eventstore.Config{
-			VATRates: []eventstore.VATRate{
+			VATRates: []eventio.VATRate{
 				{
 					Code:      "Standard",
 					Rate:      0.2,
 					ValidFrom: "epoch",
 				},
 			},
-			CurrencyRates: []eventstore.CurrencyRate{
+			CurrencyRates: []eventio.CurrencyRate{
 				{
 					Code:      "GBP",
 					Rate:      1,
 					ValidFrom: "epoch",
 				},
 			},
-			PricingPlans: []eventstore.PricingPlan{
+			PricingPlans: []eventio.PricingPlan{
 				{
 					PlanGUID:  eventstore.ComputePlanGUID,
 					ValidFrom: "epoch",
 					Name:      "PLAN1",
-					Components: []eventstore.PricingPlanComponent{
+					Components: []eventio.PricingPlanComponent{
 						{
 							Name:         "compute",
 							Formula:      "1",
@@ -109,26 +109,26 @@ var _ = Describe("Currency Conversion", func() {
 	----------------------------------------------------------------------------------------*/
 	It("converts USD at the defined rate", func() {
 		cfg = eventstore.Config{
-			VATRates: []eventstore.VATRate{
+			VATRates: []eventio.VATRate{
 				{
 					Code:      "Standard",
 					Rate:      0.2,
 					ValidFrom: "epoch",
 				},
 			},
-			CurrencyRates: []eventstore.CurrencyRate{
+			CurrencyRates: []eventio.CurrencyRate{
 				{
 					Code:      "USD",
 					Rate:      0.8,
 					ValidFrom: "epoch",
 				},
 			},
-			PricingPlans: []eventstore.PricingPlan{
+			PricingPlans: []eventio.PricingPlan{
 				{
 					PlanGUID:  eventstore.ComputePlanGUID,
 					ValidFrom: "epoch",
 					Name:      "PLAN1",
-					Components: []eventstore.PricingPlanComponent{
+					Components: []eventio.PricingPlanComponent{
 						{
 							Name:         "compute",
 							Formula:      "100",
@@ -177,14 +177,14 @@ var _ = Describe("Currency Conversion", func() {
 	----------------------------------------------------------------------------------------*/
 	It("should return one BillableEvent with multiple pricing components when range intercepts changing currency rates", func() {
 		cfg = eventstore.Config{
-			VATRates: []eventstore.VATRate{
+			VATRates: []eventio.VATRate{
 				{
 					Code:      "Standard",
 					Rate:      0.2,
 					ValidFrom: "epoch",
 				},
 			},
-			CurrencyRates: []eventstore.CurrencyRate{
+			CurrencyRates: []eventio.CurrencyRate{
 				{
 					Code:      "USD",
 					Rate:      2,
@@ -196,12 +196,12 @@ var _ = Describe("Currency Conversion", func() {
 					ValidFrom: "2001-02-01",
 				},
 			},
-			PricingPlans: []eventstore.PricingPlan{
+			PricingPlans: []eventio.PricingPlan{
 				{
 					PlanGUID:  eventstore.ComputePlanGUID,
 					ValidFrom: "epoch",
 					Name:      "PLAN1",
-					Components: []eventstore.PricingPlanComponent{
+					Components: []eventio.PricingPlanComponent{
 						{
 							Name:         "compute",
 							Formula:      "1",
@@ -256,14 +256,14 @@ var _ = Describe("Currency Conversion", func() {
 	----------------------------------------------------------------------------------------*/
 	It("should return single BillableEvent with two pricing components with different currencies", func() {
 		cfg = eventstore.Config{
-			VATRates: []eventstore.VATRate{
+			VATRates: []eventio.VATRate{
 				{
 					Code:      "Standard",
 					Rate:      0.2,
 					ValidFrom: "epoch",
 				},
 			},
-			CurrencyRates: []eventstore.CurrencyRate{
+			CurrencyRates: []eventio.CurrencyRate{
 				{
 					Code:      "GBP",
 					Rate:      1,
@@ -275,12 +275,12 @@ var _ = Describe("Currency Conversion", func() {
 					ValidFrom: "2001-01-01",
 				},
 			},
-			PricingPlans: []eventstore.PricingPlan{
+			PricingPlans: []eventio.PricingPlan{
 				{
 					PlanGUID:  eventstore.ComputePlanGUID,
 					ValidFrom: "2001-01-01",
 					Name:      "PLAN1",
-					Components: []eventstore.PricingPlanComponent{
+					Components: []eventio.PricingPlanComponent{
 						{
 							Name:         "little-price",
 							Formula:      "1",

--- a/eventstore/store_forecast_events_test.go
+++ b/eventstore/store_forecast_events_test.go
@@ -35,11 +35,11 @@ var _ = Describe("ForecastBillingEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	*-----------------------------------------------------------------------------------*/
 	It("Should return one BillingEvent for each simulated app UsageEvent", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "APP-PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "node-cost",
 					Formula:      "($time_in_seconds / 3600) * $number_of_nodes",
@@ -49,11 +49,11 @@ var _ = Describe("ForecastBillingEvents", func() {
 			},
 		})
 		dummyServicePlan := "d77af28f-735f-47d0-8a21-be3163baa0e9"
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  dummyServicePlan,
 			ValidFrom: "2001-01-01",
 			Name:      "SRV-PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "storage-cost",
 					Formula:      "($time_in_seconds / 3600) * $storage_in_mb",
@@ -178,11 +178,11 @@ var _ = Describe("ForecastBillingEvents", func() {
 	})
 
 	It("should never persist simulated events to the store", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "APP-PLAN1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "node-cost",
 					Formula:      "($time_in_seconds / 3600) * $number_of_nodes",

--- a/eventstore/store_formula_test.go
+++ b/eventstore/store_formula_test.go
@@ -3,7 +3,7 @@ package eventstore_test
 import (
 	"math"
 
-	"github.com/alphagov/paas-billing/eventstore"
+	"github.com/alphagov/paas-billing/eventio"
 	"github.com/alphagov/paas-billing/testenv"
 	uuid "github.com/satori/go.uuid"
 
@@ -14,11 +14,11 @@ import (
 var _ = Describe("Pricing Formulae", func() {
 
 	var insert = func(formula string, out interface{}) error {
-		plan := eventstore.PricingPlan{
+		plan := eventio.PricingPlan{
 			Name:      "FormulaTestPlan",
 			PlanGUID:  uuid.NewV4().String(),
 			ValidFrom: "2000-01-01",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "FormulaTestPlanComponent",
 					VATCode:      "Standard",

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -33,11 +33,11 @@ var _ = Describe("Store", func() {
 	})
 
 	It("should normalize *_usage_events tables into a consistant format with durations", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "APP_PLAN_1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -46,11 +46,11 @@ var _ = Describe("Store", func() {
 				},
 			},
 		})
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
 			ValidFrom: "2001-01-01",
 			Name:      "DB_PLAN_1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 1",
@@ -124,11 +124,11 @@ var _ = Describe("Store", func() {
 	})
 
 	It("only outputs a single resource row because the others have zero duration", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "APP_PLAN_1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -156,11 +156,11 @@ var _ = Describe("Store", func() {
 	})
 
 	It("should ensure plan has unique plan_guid + valid_from", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "APP_PLAN_1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -169,11 +169,11 @@ var _ = Describe("Store", func() {
 				},
 			},
 		})
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "APP_PLAN_1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -192,12 +192,12 @@ var _ = Describe("Store", func() {
 	DescribeTable("reject placing plans with valid_from that isn't the start of the month",
 		func(timestamp string) {
 			db, err := testenv.Open(eventstore.Config{
-				PricingPlans: []eventstore.PricingPlan{
+				PricingPlans: []eventio.PricingPlan{
 					{
 						PlanGUID:  uuid.NewV4().String(),
 						ValidFrom: timestamp,
 						Name:      "bad-plan",
-						Components: []eventstore.PricingPlanComponent{
+						Components: []eventio.PricingPlanComponent{
 							{
 								Name:         "compute",
 								Formula:      "1",
@@ -223,7 +223,7 @@ var _ = Describe("Store", func() {
 	DescribeTable("reject vat_rates with valid_from that isn't the start of the month",
 		func(timestamp string) {
 			db, err := testenv.Open(eventstore.Config{
-				VATRates: []eventstore.VATRate{
+				VATRates: []eventio.VATRate{
 					{
 						ValidFrom: timestamp,
 						Code:      "Standard",
@@ -246,7 +246,7 @@ var _ = Describe("Store", func() {
 	DescribeTable("reject currency_rates with valid_from that isn't the start of the month",
 		func(timestamp string) {
 			db, err := testenv.Open(eventstore.Config{
-				CurrencyRates: []eventstore.CurrencyRate{
+				CurrencyRates: []eventio.CurrencyRate{
 					{
 						ValidFrom: timestamp,
 						Code:      "USD",
@@ -269,7 +269,7 @@ var _ = Describe("Store", func() {
 	DescribeTable("allow whitelisted currency codes",
 		func(code string) {
 			db, err := testenv.Open(eventstore.Config{
-				CurrencyRates: []eventstore.CurrencyRate{
+				CurrencyRates: []eventio.CurrencyRate{
 					{
 						ValidFrom: "2001-01-01",
 						Code:      code,
@@ -290,7 +290,7 @@ var _ = Describe("Store", func() {
 	DescribeTable("reject unknown currency_codes",
 		func(code string) {
 			db, err := testenv.Open(eventstore.Config{
-				CurrencyRates: []eventstore.CurrencyRate{
+				CurrencyRates: []eventio.CurrencyRate{
 					{
 						ValidFrom: "2001-01-01",
 						Code:      code,
@@ -312,7 +312,7 @@ var _ = Describe("Store", func() {
 	DescribeTable("allow whitelisted vat_rates",
 		func(code string) {
 			db, err := testenv.Open(eventstore.Config{
-				VATRates: []eventstore.VATRate{
+				VATRates: []eventio.VATRate{
 					{
 						ValidFrom: "2001-01-01",
 						Code:      code,
@@ -333,7 +333,7 @@ var _ = Describe("Store", func() {
 	DescribeTable("reject unknown vat_rates",
 		func(code string) {
 			db, err := testenv.Open(eventstore.Config{
-				VATRates: []eventstore.VATRate{
+				VATRates: []eventio.VATRate{
 					{
 						ValidFrom: "2001-01-01",
 						Code:      code,

--- a/eventstore/store_usage_events_test.go
+++ b/eventstore/store_usage_events_test.go
@@ -35,11 +35,11 @@ var _ = Describe("GetUsageEvents", func() {
 	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
 	*-----------------------------------------------------------------------------------*/
 	It("should return one UsageEvent for each STARTED/STOPPED pair of RawEvent", func() {
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",
 			Name:      "APP_PLAN_1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 0.01",
@@ -48,11 +48,11 @@ var _ = Describe("GetUsageEvents", func() {
 				},
 			},
 		})
-		cfg.AddPlan(eventstore.PricingPlan{
+		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
 			ValidFrom: "2001-01-01",
 			Name:      "DB_PLAN_1",
-			Components: []eventstore.PricingPlanComponent{
+			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
 					Formula:      "ceil($time_in_seconds/3600) * 1",

--- a/fakes/fake_event_store.go
+++ b/fakes/fake_event_store.go
@@ -26,6 +26,19 @@ type FakeEventStore struct {
 	refreshReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GetPricingPlansStub        func(filter eventio.PricingPlanFilter) ([]eventio.PricingPlan, error)
+	getPricingPlansMutex       sync.RWMutex
+	getPricingPlansArgsForCall []struct {
+		filter eventio.PricingPlanFilter
+	}
+	getPricingPlansReturns struct {
+		result1 []eventio.PricingPlan
+		result2 error
+	}
+	getPricingPlansReturnsOnCall map[int]struct {
+		result1 []eventio.PricingPlan
+		result2 error
+	}
 	StoreEventsStub        func(events []eventio.RawEvent) error
 	storeEventsMutex       sync.RWMutex
 	storeEventsArgsForCall []struct {
@@ -212,6 +225,57 @@ func (fake *FakeEventStore) RefreshReturnsOnCall(i int, result1 error) {
 	fake.refreshReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeEventStore) GetPricingPlans(filter eventio.PricingPlanFilter) ([]eventio.PricingPlan, error) {
+	fake.getPricingPlansMutex.Lock()
+	ret, specificReturn := fake.getPricingPlansReturnsOnCall[len(fake.getPricingPlansArgsForCall)]
+	fake.getPricingPlansArgsForCall = append(fake.getPricingPlansArgsForCall, struct {
+		filter eventio.PricingPlanFilter
+	}{filter})
+	fake.recordInvocation("GetPricingPlans", []interface{}{filter})
+	fake.getPricingPlansMutex.Unlock()
+	if fake.GetPricingPlansStub != nil {
+		return fake.GetPricingPlansStub(filter)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.getPricingPlansReturns.result1, fake.getPricingPlansReturns.result2
+}
+
+func (fake *FakeEventStore) GetPricingPlansCallCount() int {
+	fake.getPricingPlansMutex.RLock()
+	defer fake.getPricingPlansMutex.RUnlock()
+	return len(fake.getPricingPlansArgsForCall)
+}
+
+func (fake *FakeEventStore) GetPricingPlansArgsForCall(i int) eventio.PricingPlanFilter {
+	fake.getPricingPlansMutex.RLock()
+	defer fake.getPricingPlansMutex.RUnlock()
+	return fake.getPricingPlansArgsForCall[i].filter
+}
+
+func (fake *FakeEventStore) GetPricingPlansReturns(result1 []eventio.PricingPlan, result2 error) {
+	fake.GetPricingPlansStub = nil
+	fake.getPricingPlansReturns = struct {
+		result1 []eventio.PricingPlan
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeEventStore) GetPricingPlansReturnsOnCall(i int, result1 []eventio.PricingPlan, result2 error) {
+	fake.GetPricingPlansStub = nil
+	if fake.getPricingPlansReturnsOnCall == nil {
+		fake.getPricingPlansReturnsOnCall = make(map[int]struct {
+			result1 []eventio.PricingPlan
+			result2 error
+		})
+	}
+	fake.getPricingPlansReturnsOnCall[i] = struct {
+		result1 []eventio.PricingPlan
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeEventStore) StoreEvents(events []eventio.RawEvent) error {
@@ -643,6 +707,8 @@ func (fake *FakeEventStore) Invocations() map[string][][]interface{} {
 	defer fake.initMutex.RUnlock()
 	fake.refreshMutex.RLock()
 	defer fake.refreshMutex.RUnlock()
+	fake.getPricingPlansMutex.RLock()
+	defer fake.getPricingPlansMutex.RUnlock()
 	fake.storeEventsMutex.RLock()
 	defer fake.storeEventsMutex.RUnlock()
 	fake.getEventsMutex.RLock()

--- a/testenv/config.go
+++ b/testenv/config.go
@@ -1,21 +1,24 @@
 package testenv
 
-import "github.com/alphagov/paas-billing/eventstore"
+import (
+	"github.com/alphagov/paas-billing/eventio"
+	"github.com/alphagov/paas-billing/eventstore"
+)
 
 var BasicConfig = eventstore.Config{
-	VATRates: []eventstore.VATRate{
+	VATRates: []eventio.VATRate{
 		{
 			Code:      "Standard",
 			Rate:      0.2,
 			ValidFrom: "epoch",
 		},
 	},
-	CurrencyRates: []eventstore.CurrencyRate{
+	CurrencyRates: []eventio.CurrencyRate{
 		{
 			Code:      "GBP",
 			Rate:      1,
 			ValidFrom: "epoch",
 		},
 	},
-	PricingPlans: []eventstore.PricingPlan{},
+	PricingPlans: []eventio.PricingPlan{},
 }


### PR DESCRIPTION
## What

This implements a GetPricingPlans() method for EventStore to allow querying the configured pricing_plans data for a given date range and then exposes this the to public via the eventserver at `/pricing_plans`.

## How to review

* Code review
* Check tests make sense and work
* Maybe run the app with `make run-dev` and check that hitting `http://localhost:8881/pricing_plans?range_start=2017-01-01&range_stop=2019-01-01` works as expected.

## Who can review

Not @chrisfarms
