### PR TITLE
Handle Compose-Events newer than CF-Events

### DIFF
--- a/config.json
+++ b/config.json
@@ -825,11 +825,11 @@
 			"name": "redis tiny-clustered-3.2",
 			"valid_from": "2017-01-01",
 			"plan_guid": "957e6177-323c-4eeb-8630-c4bfa979a86c",
+			"number_of_nodes": 1,
 			"components": [
 				{
 					"name": "instance",
 					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.018",
-					"number_of_nodes": 1,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}
@@ -839,11 +839,11 @@
 			"name": "redis tiny-unclustered-3.2",
 			"valid_from": "2017-01-01",
 			"plan_guid": "ffa2f099-e416-4632-b936-32ab0c0c0166",
+			"number_of_nodes": 1,
 			"components": [
 				{
 					"name": "instance",
 					"formula": "$number_of_nodes * ceil($time_in_seconds/3600) * 0.018",
-					"number_of_nodes": 1,
 					"currency_code": "USD",
 					"vat_code": "Standard"
 				}

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -123,7 +123,10 @@ INSERT INTO events with
 					c.raw_message->'data'->>'deployment'
 					from '[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
 				)::uuid as resource_guid,
-				NULL as resource_name,
+				(case
+				 when s.created_at > c.created_at then (s.raw_message->>'service_instance_name')
+				 else NULL::text
+				end) as resource_name,
 				'service'::text as resource_type,
 				(s.raw_message->>'org_guid')::uuid as org_guid,
 				(s.raw_message->>'space_guid')::uuid as space_guid,
@@ -167,13 +170,13 @@ INSERT INTO events with
 			coalesce(
 				memory_in_mb,
 				(array_remove(
-						array_agg(memory_in_mb) over prev_events
+					array_agg(memory_in_mb) over prev_events
 				, NULL))[1]
 			) as memory_in_mb,
 			coalesce(
 				storage_in_mb,
 				(array_remove(
-						array_agg(storage_in_mb) over prev_events
+					array_agg(storage_in_mb) over prev_events
 				, NULL))[1]
 			) as storage_in_mb,
 			state

--- a/eventstore/store_usage_events_test.go
+++ b/eventstore/store_usage_events_test.go
@@ -272,4 +272,103 @@ var _ = Describe("GetUsageEvents", func() {
 		}))
 	})
 
+	/*-----------------------------------------------------------------------------------*
+	       00:00                   01:00               02:00                             .
+	         |                       |                   |                               .
+	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
+	 .   .   [==================db1======================]   .   .   .   .   .   .   .   .
+	 .   .   |   .   .               |   .   .   .       |   .   .   .   .   .   .   .   .
+	    compose-scale               start              stop                              .
+	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
+	<=======================================PLAN1=======================================>.
+	 .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .   .
+	-------------------------------------------------------------------------------------*/
+	It("should use the compose event as the EventStart  ", func() {
+		cfg.AddVATRate(eventio.VATRate{
+			Code:      "Zero",
+			Rate:      0,
+			ValidFrom: "epoch",
+		})
+		plan := eventio.PricingPlan{
+			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			ValidFrom:     "2001-01-01",
+			Name:          "PLAN1",
+			NumberOfNodes: 1,
+			MemoryInMB:    1024,
+			StorageInMB:   2048,
+			Components: []eventio.PricingPlanComponent{
+				{
+					Name:         "compose",
+					Formula:      "ceil($time_in_seconds/3600) * $memory_in_mb * $storage_in_mb * $number_of_nodes",
+					CurrencyCode: "GBP",
+					VATCode:      "Zero",
+				},
+			},
+		}
+		cfg.AddPlan(plan)
+
+		db, err := testenv.Open(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		defer db.Close()
+
+		service1EventScale := testenv.Row{
+			"event_id":    "audit-id-000000000003",
+			"created_at":  "2001-01-01T00:00Z",
+			"raw_message": json.RawMessage(` {"id": "audit-id-000000000003", "ip": "", "data": {"units": "2", "memory": "2 GB", "cluster": "gds-eu-west1-c00", "storage": "4 GB", "deployment": "prod-aaaaaaaa-0000-0000-0000-000000000001"}, "event": "deployment.scale.members", "_links": {"alerts": {"href": "", "templated": false}, "backups": {"href": "", "templated": false}, "cluster": {"href": "", "templated": false}, "scalings": {"href": "", "templated": false}, "portal_users": {"href": "", "templated": false}, "compose_web_ui": {"href": "", "templated": false}}, "user_id": "", "account_id": "58d3e39c0045bb00135ee6ad", "cluster_id": "5941cf9f859d2c0015000021", "created_at": "2001-01-01T02:00:00.000Z", "user_agent": "", "deployment_id": "59de3e8cc9ecc40010324fc6"}`),
+		}
+		service1EventStart := testenv.Row{
+			"guid":        "00000000-0000-0000-0000-000000000001",
+			"created_at":  "2001-01-01T01:00Z",
+			"raw_message": json.RawMessage(`{"state": "CREATED", "org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944", "space_guid": "276f4886-ac40-492d-a8cd-b2646637ba76", "space_name": "sandbox", "service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489", "service_label": "compose-db", "service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5", "service_plan_name": "PLAN1", "service_instance_guid": "aaaaaaaa-0000-0000-0000-000000000001", "service_instance_name": "db1", "service_instance_type": "managed_service_instance"}`),
+		}
+		service1EventStop := testenv.Row{
+			"guid":        "00000000-0000-0000-0000-000000000005",
+			"created_at":  "2001-01-01T02:00Z",
+			"raw_message": json.RawMessage(`{"state": "DELETED", "org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944", "space_guid": "276f4886-ac40-492d-a8cd-b2646637ba76", "space_name": "sandbox", "service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489", "service_label": "compose-db", "service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5", "service_plan_name": "PLAN1", "service_instance_guid": "aaaaaaaa-0000-0000-0000-000000000001", "service_instance_name": "db1", "service_instance_type": "managed_service_instance"}`),
+		}
+
+		Expect(db.Insert("service_usage_events", service1EventStart, service1EventStop)).To(Succeed())
+		Expect(db.Insert("compose_audit_events", service1EventScale)).To(Succeed())
+
+		Expect(db.Schema.Refresh()).To(Succeed())
+
+		events, err := db.Schema.GetUsageEvents(eventio.EventFilter{
+			RangeStart: "2001-01-01",
+			RangeStop:  "2001-02-01",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(events).To(HaveLen(2))
+
+		events[0].EventGUID = "unknowable-guid"
+		Expect(events[0]).To(Equal(eventio.UsageEvent{
+			EventGUID:    "unknowable-guid",
+			EventStart:   "2001-01-01T00:00:00+00:00",
+			EventStop:    "2001-01-01T01:00:00+00:00",
+			ResourceGUID: "aaaaaaaa-0000-0000-0000-000000000001",
+			ResourceName: "db1",
+			ResourceType: "service",
+			OrgGUID:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
+			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			MemoryInMB:   2048,
+			StorageInMB:  4096,
+		}))
+
+		Expect(events[1]).To(Equal(eventio.UsageEvent{
+			EventGUID:    "00000000-0000-0000-0000-000000000001",
+			EventStart:   "2001-01-01T01:00:00+00:00",
+			EventStop:    "2001-01-01T02:00:00+00:00",
+			ResourceGUID: "aaaaaaaa-0000-0000-0000-000000000001",
+			ResourceName: "db1",
+			ResourceType: "service",
+			OrgGUID:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
+			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			MemoryInMB:   2048,
+			StorageInMB:  4096,
+		}))
+
+	})
+
 })


### PR DESCRIPTION
# What

When calculating STARTED events for resources that we have never seen a
true STARTED/CREATED event for, the earlist date we can use is the date
that we started collecting the data.

We had events for compose that predate our collection of cf events.

This led to a situation where a compose event became the first seen
STARTED event for a service ... this was never expected to happen and so
compose events always fetch their name from the "previous" event in the
WINDOW (to handle renames gracefully).... as a result we had events
without a resource name, which is a constraint error and so caused the
application to shutdown as it believed it was operating with bad data
(which it was).

To resolve this, we fetch the name from the paired service_usage_event
in the case when the compose event is newer.

...Also fixed an slight error in the config which was causing redis services to not be calculated correctly.

# How to review

Code review should be enough.

# Who can review

Not meeeeeee