### PR TITLE
Fix STAGING_STOP events being iterpreted as app STOP events

### DIFF
--- a/config.json
+++ b/config.json
@@ -89,6 +89,25 @@
 			]
 		},
 		{
+			"name": "staging",
+			"valid_from": "2017-01-01",
+			"plan_guid": "9d071c77-7a68-4346-9981-e8dafac95b6f",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "$number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				},
+				{
+					"name": "platform",
+					"formula": "($number_of_nodes * ceil($time_in_seconds / 3600) * ($memory_in_mb/1024.0) * 0.01) * 0.40",
+					"currency_code": "USD",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
 			"name": "task",
 			"valid_from": "2017-01-01",
 			"plan_guid": "ebfa9453-ef66-450c-8c37-d53dfd931038",

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -108,11 +108,11 @@ INSERT INTO events with
 				'app'::text as resource_type,                              -- resource_type for staging of resources
 				(raw_message->>'org_guid')::uuid as org_guid,
 				(raw_message->>'space_guid')::uuid as space_guid,
-				'f4d4b95a-f55e-4593-8d54-3364c25798c4'::uuid as plan_guid,  -- plan guid for all staging of resources
-				'app'::text as plan_name,                                  -- plan name for all staging of resources
+				'9d071c77-7a68-4346-9981-e8dafac95b6f'::uuid as plan_guid,  -- plan guid for all staging of resources
+				'staging'::text as plan_name,                                  -- plan name for all staging of resources
 				'4f6f0a18-cdd4-4e51-8b6b-dc39b696e61b'::uuid as service_guid,
 				'app'::text as service_name,
-				coalesce(raw_message->>'instance_count', '1')::numeric as number_of_nodes,
+				'1'::numeric as number_of_nodes,
 				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::numeric as memory_in_mb,
 				'0'::numeric as storage_in_mb,
 				(case
@@ -213,7 +213,7 @@ INSERT INTO events with
 			raw_events_with_injected_values
 		window
 			resource_states as (
-				partition by resource_guid
+				partition by resource_guid, plan_guid
 				order by created_at, event_sequence
 				rows between current row and 1 following
 			)

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -23,6 +23,7 @@ const (
 	ComputePlanGUID       = "f4d4b95a-f55e-4593-8d54-3364c25798c4"
 	ComputeServiceGUID    = "4f6f0a18-cdd4-4e51-8b6b-dc39b696e61b"
 	TaskPlanGUID          = "ebfa9453-ef66-450c-8c37-d53dfd931038"
+	StagingPlanGUID       = "9d071c77-7a68-4346-9981-e8dafac95b6f"
 	DefaultInitTimeout    = 5 * time.Minute
 	DefaultRefreshTimeout = 5 * time.Minute
 	DefaultStoreTimeout   = 45 * time.Second

--- a/eventstore/store_billable_events_test.go
+++ b/eventstore/store_billable_events_test.go
@@ -36,9 +36,9 @@ var _ = Describe("GetBillableEvents", func() {
 	*-----------------------------------------------------------------------------------*/
 	It("Should return one BillingEvent for an app in staging state", func() {
 		cfg.AddPlan(eventio.PricingPlan{
-			PlanGUID:  eventstore.ComputePlanGUID,
+			PlanGUID:  eventstore.StagingPlanGUID,
 			ValidFrom: "2001-01-01",
-			Name:      "PLAN1",
+			Name:      "STAGING_PLAN_1",
 			Components: []eventio.PricingPlanComponent{
 				{
 					Name:         "compute",
@@ -84,7 +84,7 @@ var _ = Describe("GetBillableEvents", func() {
 			ResourceType:  "app",
 			OrgGUID:       "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:     "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:      "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+			PlanGUID:      eventstore.StagingPlanGUID,
 			NumberOfNodes: 1,
 			MemoryInMB:    1024,
 			StorageInMB:   0,
@@ -94,7 +94,7 @@ var _ = Describe("GetBillableEvents", func() {
 				Details: []eventio.PriceComponent{
 					{
 						Name:         "compute",
-						PlanName:     "PLAN1",
+						PlanName:     "STAGING_PLAN_1",
 						Start:        "2001-01-01T00:00:00+00:00",
 						Stop:         "2001-01-01T00:01:00+00:00",
 						VatRate:      "0.2",

--- a/eventstore/store_usage_events.go
+++ b/eventstore/store_usage_events.go
@@ -71,7 +71,7 @@ func (s *EventStore) getUsageEventRows(tx *sql.Tx, filter eventio.EventFilter) (
 			duration && $1::tstzrange
 			%s
 		order by
-			lower(duration)
+			lower(duration), event_guid
 	`, filterQuery), args...)
 	if err != nil {
 		return nil, err

--- a/main_app_test.go
+++ b/main_app_test.go
@@ -65,7 +65,7 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 	})
 
 	By("Waiting for the EventStore to report it has been initialized", func() {
-		Eventually(session.Out, 5*time.Second).Should(Say("paas-billing.store.initializing"))
+		Eventually(session.Out, 20*time.Second).Should(Say("paas-billing.store.initializing"))
 		Eventually(session.Out, 60*time.Second).Should(Say("paas-billing.store.initialized"))
 	})
 


### PR DESCRIPTION
What
----

When we added the processing of STAGING_START / STAGING_STOP events we
attempted to roll them up into the regular app START / STOP events to
simplify the bills.

Unfortunatly this introduced a bug where a STAGING_STOP event could be
interperated as an application STOP event in certain circumstances (when
it came in late or at an identical time). This resulted in many
applications being undercharged.

There was also another error in the staging processing that used the
number_of_nodes from the target application, when in fact staging only
eveer uses a single node.

To resolve these, "staging" has been broken out into it's own "plan"
with it's own "plan_guid" in the same way that tasks are, and we then
partition by both the resource_guid AND the plan_guid when calculating
the ranges to ensure that only related events are paired up.

This may mean the bills are a bit more noisey as there will be more
events than previously (extra ones for "staging")

How to review
-----

* Code review
* Check the logic
* After merge ask for a bump PR (or make one)

Who can review
-----

Not @chrisfarms
