### PR TITLE
[#159268475] Fix service plan update events

### DIFF
--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -116,9 +116,9 @@ INSERT INTO events with
 				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::numeric as memory_in_mb,
 				'0'::numeric as storage_in_mb,
 				(case
-				 when (raw_message->>'state') = 'STAGING_STARTED' then 'STARTED'
-				 when (raw_message->>'state') = 'STAGING_STOPPED' then 'STOPPED'
-				 end)::resource_state as state
+					when (raw_message->>'state') = 'STAGING_STARTED' then 'STARTED'
+					when (raw_message->>'state') = 'STAGING_STOPPED' then 'STOPPED'
+				end)::resource_state as state
 			from
 				app_usage_events
 			where
@@ -134,8 +134,8 @@ INSERT INTO events with
 					from '[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$'
 				)::uuid as resource_guid,
 				(case
-				 when s.created_at > c.created_at then (s.raw_message->>'service_instance_name')
-				 else NULL::text
+					when s.created_at > c.created_at then (s.raw_message->>'service_instance_name')
+					else NULL::text
 				end) as resource_name,
 				'service'::text as resource_type,
 				(s.raw_message->>'org_guid')::uuid as org_guid,


### PR DESCRIPTION
What
----

I recently "fixed" an issue where START/STOP app events were getting mixed
up with STAGING_START/STAGING_STOP events by including the plan_guid in
the partition query so that START/STOP events were only considered from
the same plan to avoid "task plan" stuff getting mixed up with "app instance plan" stuff

However, this did not take into account that resources can change their plan_guid
during UPDATE events!, and we did not have a test to catch this regression.

This adds a test case for a service instance getting a plan change via an UPDATE service_usage_event that illustrates the problem and resolves it by introduceing an "event_type" field during the processing of events that can be used to isolate exactly which event types should be getting paired up instead of relying on the plan_guid (which can change).

How to review
-----

* Code review
* Review and Run tests

Who can review
-----

Not @chrisfarms
