### PR TITLE
Fix various typos in comments / strings / names

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ UsageEvents are the normalized, processed events. Each event represents some kin
 
 A single event might represent a Cloudfoundry app running for 20mins, with 64MB memory and 3x instances. Another event might represent a medium mysql database that was running for 3hrs.
 
-The `resource_guid` field references the subject of the event. For a cloudfoundry app event (`resource_type=app`) this would be an app guid. For a cloudoundry service event (`resource_type=service`) this would be a service instance guid.
+The `resource_guid` field references the subject of the event. For a cloudfoundry app event (`resource_type=app`) this would be an app guid. For a cloudfoundry service event (`resource_type=service`) this would be a service instance guid.
 
 **Authorization:**
 
-The `Authorization` header must contain a valid Cloudfoundy bearer token with permission to access the requested orgs is required.
+The `Authorization` header must contain a valid Cloudfoundry bearer token with permission to access the requested orgs is required.
 
 **Query parameters:**
 
@@ -403,7 +403,7 @@ curl -s -G 'http://localhost:8881/forecast_events' \
 
 ### `GET /pricing_plans`
 
-PricingPlans define how the costs for resources are applied. The PricingPlans are setup in the configuraiton json file. Each UsageEvent's PlanGUID should have a matching PricingPlan for a given point in time.
+PricingPlans define how the costs for resources are applied. The PricingPlans are setup in the configuration json file. Each UsageEvent's PlanGUID should have a matching PricingPlan for a given point in time.
 
 Each PricingPlan may be made up of multiple PricingComponents (for example a database service may have components for the CPU/VM instance and also for the storage used).
 

--- a/cmd/db_repair/README.md
+++ b/cmd/db_repair/README.md
@@ -34,7 +34,7 @@ go build -o db_repair
 
 ## Configuration
 
-Configuation is via environment variables.
+Configuration is via environment variables.
 
 | Name | required | Description |
 |---|---|---|

--- a/eventcollector/collector.go
+++ b/eventcollector/collector.go
@@ -17,9 +17,9 @@ const (
 type state string
 
 const (
-	// Syncing state means that the collector has just started and need to immediatly do a fetch to catchup
+	// Syncing state means that the collector has just started and need to immediately do a fetch to catchup
 	Syncing state = "sync"
-	// Scheduled means that we have caught up with latest events and are schuduled to run again later in Schedule time
+	// Scheduled means that we have caught up with latest events and are scheduled to run again later in Schedule time
 	Scheduled state = "waiting"
 	// Collecting means the collector thinks it probably has more to collect but is rate limited by MinWaitTime
 	Collecting state = "collecting"
@@ -122,7 +122,7 @@ func (c *EventCollector) getLastEvent() (*eventio.RawEvent, error) {
 	return &lastEvents[0], nil
 }
 
-// wait returns a channel that closes after the collection schedule time has elaspsed
+// wait returns a channel that closes after the collection schedule time has elapsed
 func (c *EventCollector) waitDuration() time.Duration {
 	delay := c.schedule
 	if c.state == Syncing {

--- a/eventfetchers/composefetcher/compose_fetcher.go
+++ b/eventfetchers/composefetcher/compose_fetcher.go
@@ -45,7 +45,7 @@ func (e *ComposeEventFetcher) fetchScaleEvents(ctx context.Context, newerThan *t
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("interupted by context cancelation")
+			return nil, fmt.Errorf("interrupted by context cancellation")
 		default:
 		}
 		e.logger.Info("fetching", lager.Data{

--- a/eventfetchers/composefetcher/compose_fetcher_test.go
+++ b/eventfetchers/composefetcher/compose_fetcher_test.go
@@ -199,7 +199,7 @@ var _ = Describe("ComposeEventFetcher", func() {
 			cancel()
 		}()
 
-		Eventually(errs).Should(Receive(MatchError("interupted by context cancelation")))
+		Eventually(errs).Should(Receive(MatchError("interrupted by context cancellation")))
 		Expect(fakeClient.GetAuditEventsCallCount()).To(BeNumerically(">", 1))
 	})
 

--- a/eventserver/auth/uaa_authorizer.go
+++ b/eventserver/auth/uaa_authorizer.go
@@ -34,7 +34,7 @@ func (uaa *UAA) Exchange(c echo.Context) error {
 
 func (uaa *UAA) NewAuthorizer(token string) (Authorizer, error) {
 	if token == "" {
-		return nil, errors.New("no auth token: unauthozed")
+		return nil, errors.New("no auth token: unauthorized")
 	}
 	return &ClientAuthorizer{
 		endpoint: uaa.Config.Endpoint.TokenURL,
@@ -95,8 +95,8 @@ func (a *ClientAuthorizer) HasBillingAccess(requestedOrgs []string) (bool, error
 		orgGUIDs = append(orgGUIDs, org.Guid)
 	}
 
-	if ok, missmatch := SliceMatches(requestedOrgs, orgGUIDs); !ok {
-		return false, fmt.Errorf("authorizer: no access to organisation: %s", missmatch)
+	if ok, mismatch := SliceMatches(requestedOrgs, orgGUIDs); !ok {
+		return false, fmt.Errorf("authorizer: no access to organisation: %s", mismatch)
 	}
 
 	return true, nil

--- a/eventserver/auth/utils.go
+++ b/eventserver/auth/utils.go
@@ -50,7 +50,7 @@ func CreateConfigFromEnv() (*oauth2.Config, error) {
 	}, nil
 }
 
-// SliceMatches will iterate throug both slices to find any incompatibilities in
+// SliceMatches will iterate through both slices to find any incompatibilities in
 // order to determine if the requested access is indeed allowed.
 func SliceMatches(requested, allowed []string) (bool, string) {
 	for _, r := range requested {

--- a/eventserver/auth/utils_test.go
+++ b/eventserver/auth/utils_test.go
@@ -5,12 +5,12 @@ import "testing"
 func TestSliceMatches(t *testing.T) {
 	requested := []string{"a", "b", "c"}
 	allowed := []string{"a", "c"}
-	if _, missmatch := SliceMatches(requested, allowed); missmatch != "b" {
-		t.Errorf("expected to fail with missmatch 'b', got: %s", missmatch)
+	if _, mismatch := SliceMatches(requested, allowed); mismatch != "b" {
+		t.Errorf("expected to fail with missmatch 'b', got: %s", mismatch)
 	}
 
 	requested = []string{"a", "c"}
-	if ok, missmatch := SliceMatches(requested, allowed); !ok {
-		t.Errorf("expected to succeed with no missmatch, got: %s", missmatch)
+	if ok, mismatch := SliceMatches(requested, allowed); !ok {
+		t.Errorf("expected to succeed with no missmatch, got: %s", mismatch)
 	}
 }

--- a/eventserver/server_auth.go
+++ b/eventserver/server_auth.go
@@ -9,7 +9,7 @@ import (
 )
 
 // isAdmin checks if there is a token in the request with an operator scope
-// (cloud_controler.admin / cloud_controler.read_only_admin / global_auditor)
+// (cloud_controller.admin / cloud_controller.read_only_admin / global_auditor)
 // isBillingManager checks if the user has either role assigned within the org
 // (billing_manager / org_manager)
 // Either of the above should satisfy the authorizer.
@@ -38,5 +38,5 @@ func authorize(c echo.Context, uaa auth.Authenticator, orgs []string) (bool, err
 	if hasBillingAccess {
 		return true, nil
 	}
-	return false, errors.New("you need to be billing_manager or an administrator to retreive the billing data")
+	return false, errors.New("you need to be billing_manager or an administrator to retrieve the billing data")
 }

--- a/eventserver/server_billable_handler_test.go
+++ b/eventserver/server_billable_handler_test.go
@@ -116,7 +116,7 @@ var _ = Describe("BillableEventsHandler", func() {
 		defer e.Shutdown(ctx)
 
 		Expect(res.Body).To(MatchJSON(`{
-			"error": "you need to be billing_manager or an administrator to retreive the billing data"
+			"error": "you need to be billing_manager or an administrator to retrieve the billing data"
 		}`))
 		Expect(res.Code).To(Equal(401))
 		Expect(res.Header().Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))

--- a/eventserver/server_usage_handler_test.go
+++ b/eventserver/server_usage_handler_test.go
@@ -115,7 +115,7 @@ var _ = Describe("UsageEventsHandler", func() {
 		defer e.Shutdown(ctx)
 
 		Expect(res.Body).To(MatchJSON(`{
-			"error": "you need to be billing_manager or an administrator to retreive the billing data"
+			"error": "you need to be billing_manager or an administrator to retrieve the billing data"
 		}`))
 		Expect(res.Code).To(Equal(401))
 		Expect(res.Header().Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -148,7 +148,7 @@ func (s *EventStore) refresh(tx *sql.Tx) error {
 	if err := s.execFile(tx, "create_billable_event_components.sql"); err != nil {
 		return err
 	}
-	s.logger.Info("finsihed-processing-events", lager.Data{
+	s.logger.Info("finished-processing-events", lager.Data{
 		"elapsed": time.Since(startTime),
 	})
 	return nil
@@ -248,7 +248,7 @@ func (s *EventStore) initPlans(tx *sql.Tx) (err error) {
 		return err
 	}
 
-	if err := checkPlanConsistancy(tx); err != nil {
+	if err := checkPlanConsistency(tx); err != nil {
 		return err
 	}
 
@@ -596,10 +596,10 @@ func checkPricingComponents(tx *sql.Tx) error {
 	return nil
 }
 
-// checkPlanConsistancy reports an error if there are any plans in use in the
-// the existing service_usage_events data that do not have corrosponding
+// checkPlanConsistency reports an error if there are any plans in use in the
+// the existing service_usage_events data that do not have corresponding
 // pricing_plans configured
-func checkPlanConsistancy(tx *sql.Tx) error {
+func checkPlanConsistency(tx *sql.Tx) error {
 	rows, err := tx.Query(`
 		with valid_pricing_plans as (
 			select

--- a/eventstore/store_billable_events.go
+++ b/eventstore/store_billable_events.go
@@ -177,7 +177,7 @@ func (ber *BillableEventRows) Next() bool {
 	return ber.rows.Next()
 }
 
-// Err returns any errors that occured behind the scenes during processing.
+// Err returns any errors that occurred behind the scenes during processing.
 // Call this at the end of your iteration.
 func (ber *BillableEventRows) Err() error {
 	return ber.rows.Err()
@@ -190,8 +190,8 @@ func (ber *BillableEventRows) Close() error {
 }
 
 // EventJSON returns the JSON representation of the event directly from the db.
-// If you are just going to marshel the object to JSON immediately, then this
-// is probably more effcient.
+// If you are just going to marshal the object to JSON immediately, then this
+// is probably more efficient.
 func (ber *BillableEventRows) EventJSON() ([]byte, error) {
 	var b []byte
 	if err := ber.rows.Scan(&b); err != nil {

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Store", func() {
 		Expect(db.Schema.Init()).To(Succeed())
 	})
 
-	It("should normalize *_usage_events tables into a consistant format with durations", func() {
+	It("should normalize *_usage_events tables into a consistent format with durations", func() {
 		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,
 			ValidFrom: "2001-01-01",

--- a/eventstore/store_usage_events.go
+++ b/eventstore/store_usage_events.go
@@ -82,7 +82,7 @@ func (s *EventStore) getUsageEventRows(tx *sql.Tx, filter eventio.EventFilter) (
 }
 
 // GetUsageEvents returns a slice of usage events for the given filter.
-// Due to the large number of results that can be returned it is recormended
+// Due to the large number of results that can be returned it is recommended
 // you use the GetUsageEventRows version to avoid buffering everything into
 // memory
 func (s *EventStore) GetUsageEvents(filter eventio.EventFilter) ([]eventio.UsageEvent, error) {
@@ -116,7 +116,7 @@ func (ber *UsageEventRows) Next() bool {
 	return ber.rows.Next()
 }
 
-// Err returns any errors that occured behind the scenes during processing.
+// Err returns any errors that occurred behind the scenes during processing.
 // Call this at the end of your iteration.
 func (ber *UsageEventRows) Err() error {
 	return ber.rows.Err()
@@ -129,8 +129,8 @@ func (ber *UsageEventRows) Close() error {
 }
 
 // EventJSON returns the JSON representation of the event directly from the db.
-// If you are just going to marshel the object to JSON immediately, then this
-// is probably more effcient.
+// If you are just going to marshal the object to JSON immediately, then this
+// is probably more efficient.
 func (ber *UsageEventRows) EventJSON() ([]byte, error) {
 	var b []byte
 	if err := ber.rows.Scan(&b); err != nil {

--- a/main_config_test.go
+++ b/main_config_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Config", func() {
 		os.Unsetenv("PORT")
 	})
 
-	It("should set sensible defaults for the config when no envionment variables set", func() {
+	It("should set sensible defaults for the config when no environment variables set", func() {
 		cfg, err := NewConfigFromEnv()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.Logger).ToNot(BeNil())

--- a/testenv/db.go
+++ b/testenv/db.go
@@ -146,7 +146,7 @@ func (db *TempDB) Query(q string, args ...interface{}) Rows {
 }
 
 // Insert is way of inserting Row objects (generic json representations of
-// data) into the database it makes it a bit easier to read the intension of
+// data) into the database it makes it a bit easier to read the intention of
 // the insert in tests than raw sql
 func (db *TempDB) Insert(tableName string, rows ...Row) error {
 	tx, err := db.Conn.Begin()


### PR DESCRIPTION
What
----

Fixed a few minor misspellings in comments / strings etc. The only
behavioural changes should be that some error messages / log messages
will be spelled differently.

How to review
-----

* Code review (to check for unintended behavioural changes)
* Run the tests (or let Travis run them)

Who can review
-----

Anyone other than Rich.