### PR TITLE
[#158665945] Use plans `unique_id` to identify the pricing_plans (attempt 2)

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,7 +33,7 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
-			"plan_guid": "09f2a841-1997-468b-be99-15020ff6c9c4",
+			"plan_guid": "b5998c91-d379-4df7-b329-11450f8459f1",
 			"components": [
 				{
 					"name": "instance",
@@ -129,7 +129,7 @@
 		{
 			"name": "postgres tiny-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "e264800e-20cb-4bf0-99fc-84bd42681d81",
+			"plan_guid": "5f2eec8a-0cad-4ab9-b81e-d6adade2fd42",
 			"storage_in_mb": 5120,
 			"memory_in_mb": 0,
 			"components": [
@@ -150,7 +150,7 @@
 		{
 			"name": "postgres small-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "4b47d304-003d-4771-a8ba-281adc90b2a6",
+			"plan_guid": "b7d0a368-ac92-4eff-9b8d-ab4ba45bed0e",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -171,7 +171,7 @@
 		{
 			"name": "postgres small-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "3a50a98f-316b-459c-a2de-3c5616ee77e3",
+			"plan_guid": "2611d776-9991-4940-a755-880eafbc33a0",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -192,7 +192,7 @@
 		{
 			"name": "postgres small-ha-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "dbd330b0-13e7-47b5-aec2-6303430c4776",
+			"plan_guid": "359bcb39-0264-46bd-9120-0182c3829067",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -213,7 +213,7 @@
 		{
 			"name": "postgres small-ha-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "1f4439d4-5010-480e-8fe0-9e7a2be6fe90",
+			"plan_guid": "d9f1d61d-0a65-45ad-8fc9-88c921d038d2",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -234,7 +234,7 @@
 		{
 			"name": "postgres medium-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "7bbefbf0-70c1-4ae4-88af-fc2170c0b4d6",
+			"plan_guid": "9b882524-ab58-4c18-b501-d2a3f4619104",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -255,7 +255,7 @@
 		{
 			"name": "postgres medium-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "a203ff49-bbab-411b-8a3e-89df586ab696",
+			"plan_guid": "17ef8670-5134-4ae6-b7fc-9ee8e52394c5",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -276,7 +276,7 @@
 		{
 			"name": "postgres medium-ha-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "ef9ee73a-7e82-47e6-9f1b-126cdb9ef49c",
+			"plan_guid": "bf5b99c2-7990-4b66-b341-1bb83566d76e",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -297,7 +297,7 @@
 		{
 			"name": "postgres medium-ha-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "3de5429b-424a-412b-b3a7-b6b08688ce5c",
+			"plan_guid": "8d50ccc5-707c-4306-be8f-f59a158eb736",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -318,7 +318,7 @@
 		{
 			"name": "postgres large-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "8a7346f9-2c91-473c-aaba-e1a5ed8ce036",
+			"plan_guid": "238a1328-4f77-4b70-9bd9-2cdbbfb999c8",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -339,7 +339,7 @@
 		{
 			"name": "postgres large-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "f6b802ba-2c35-4e9a-84e3-4e71876c2290",
+			"plan_guid": "8ea15f55-fbd2-41a3-a679-482d67a3d9ea",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -360,7 +360,7 @@
 		{
 			"name": "postgres large-ha-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "5ca3b793-9a59-4447-8bbe-64e052102bb6",
+			"plan_guid": "dfe4ab2b-2069-41a5-ba08-2be21b0c76d3",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -381,7 +381,7 @@
 		{
 			"name": "postgres large-ha-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "1bc93270-3d89-4ddd-a916-53e1b1d899e9",
+			"plan_guid": "620055b3-fe7c-46fc-87ad-c7d8f4fe7f34",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -402,7 +402,7 @@
 		{
 			"name": "postgres xlarge-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "82278904-9e0a-4ed3-9089-f94b0304f89a",
+			"plan_guid": "1065c353-54dd-4f6b-a5b4-a4b5aa4575c6",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -423,7 +423,7 @@
 		{
 			"name": "postgres xlarge-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "31d4c25c-1a36-4fd9-869b-c0e4a3a745da",
+			"plan_guid": "3cb1947e-1df5-4483-8e9e-07c9294f9347",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -444,7 +444,7 @@
 		{
 			"name": "postgres xlarge-ha-unencrypted-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "7ae6a962-50f2-4fbd-acd1-f8f3dc5b1301",
+			"plan_guid": "7119925f-518d-4263-96ac-16990295aad6",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -465,7 +465,7 @@
 		{
 			"name": "postgres xlarge-ha-9.5",
 			"valid_from": "2017-01-01",
-			"plan_guid": "ab7b6626-4500-4df0-a3ff-280190573a30",
+			"plan_guid": "a91c8e59-8869-42fd-8a99-8989151d7353",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -486,7 +486,7 @@
 		{
 			"name": "mysql tiny-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "c03510d2-54bd-4fb0-9d9a-1e5ffb82aa39",
+			"plan_guid": "69977068-8ef5-4172-bfdb-e8cea3c14d01",
 			"storage_in_mb": 5120,
 			"memory_in_mb": 0,
 			"components": [
@@ -507,7 +507,7 @@
 		{
 			"name": "mysql small-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "7ecc2e37-905d-4d61-9c11-b747c2317b90",
+			"plan_guid": "7fdde6ea-cc27-466c-86aa-46181fc20d25",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -528,7 +528,7 @@
 		{
 			"name": "mysql small-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "e4db2b8c-b247-41dd-8cb8-9b6c0d15d7a1",
+			"plan_guid": "b0ccc8c9-09b0-4c3e-9880-091cc41c2ab5",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -549,7 +549,7 @@
 		{
 			"name": "mysql small-ha-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "6839c764-9f4c-48e2-8219-4a2c4fb687fb",
+			"plan_guid": "72279ebd-6001-4e38-aaef-72b68c4fa6fd",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -570,7 +570,7 @@
 		{
 			"name": "mysql small-ha-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "a093b624-0547-4483-aeab-df200a08ca42",
+			"plan_guid": "6aa563c1-5aeb-46a1-9509-badcf5995c96",
 			"storage_in_mb": 20480,
 			"memory_in_mb": 0,
 			"components": [
@@ -591,7 +591,7 @@
 		{
 			"name": "mysql medium-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "76f54dfc-9f6f-4a01-a538-b354091cfed8",
+			"plan_guid": "4eb35ca9-a7ec-46c6-b137-d819848536cd",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -612,7 +612,7 @@
 		{
 			"name": "mysql medium-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "d68d322c-18d5-40a4-adcf-44eea4f6054b",
+			"plan_guid": "29cdedeb-e910-4a7a-b606-2c4e42eea478",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -633,7 +633,7 @@
 		{
 			"name": "mysql medium-ha-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "60f51688-aba3-4789-b5e1-06ad243600ba",
+			"plan_guid": "e60edf62-b701-4e38-846f-b0b3db728349",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -654,7 +654,7 @@
 		{
 			"name": "mysql medium-ha-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "d76c2a54-a921-4833-839e-6ffff23a1034",
+			"plan_guid": "8d139b9e-bc82-4749-8ad6-7733980292d6",
 			"storage_in_mb": 102400,
 			"memory_in_mb": 0,
 			"components": [
@@ -675,7 +675,7 @@
 		{
 			"name": "mysql large-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "55466bc0-cb3f-497c-bed7-43b95d4b0dab",
+			"plan_guid": "6725bf1f-71e8-447a-b6a1-659247fcc03c",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -696,7 +696,7 @@
 		{
 			"name": "mysql large-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "7e14cdc6-5de1-40dc-8d86-535149a59300",
+			"plan_guid": "98a9b7cf-e067-4915-8190-ce8224dd04dc",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -717,7 +717,7 @@
 		{
 			"name": "mysql large-ha-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "be7c7124-6d08-4856-a311-d9912110cb9e",
+			"plan_guid": "63cdac92-9e44-42a6-ba3f-7be3dccf5dc6",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -738,7 +738,7 @@
 		{
 			"name": "mysql large-ha-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "2ee14c9f-a66d-440c-bddb-233c31a1a4b2",
+			"plan_guid": "d5efbf83-5e00-47a5-a668-2ef1307d5a23",
 			"storage_in_mb": 524288,
 			"memory_in_mb": 0,
 			"components": [
@@ -759,7 +759,7 @@
 		{
 			"name": "mysql xlarge-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "6c7ef397-0f8b-4157-a566-d4e7b580417b",
+			"plan_guid": "a37144bf-4e05-451b-87ba-0a2c57a23a91",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -780,7 +780,7 @@
 		{
 			"name": "mysql xlarge-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "b7618d38-452e-47f1-b43e-dc44c4969d70",
+			"plan_guid": "e03020e8-eaed-49c2-bd58-23b7cb871c22",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -801,7 +801,7 @@
 		{
 			"name": "mysql xlarge-ha-unencrypted-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "004592ae-8856-4124-9fb1-8af8e54d14f3",
+			"plan_guid": "065a7de5-28e8-4de1-8a39-4b4f752e2f2f",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -822,7 +822,7 @@
 		{
 			"name": "mysql xlarge-ha-5.7",
 			"valid_from": "2017-01-01",
-			"plan_guid": "8bf361e0-4cc5-4da0-a5de-be934fac96bf",
+			"plan_guid": "4edc975c-3f07-46f1-bd87-ecb35b76298f",
 			"storage_in_mb": 2097152,
 			"memory_in_mb": 0,
 			"components": [
@@ -843,7 +843,7 @@
 		{
 			"name": "redis tiny-clustered-3.2",
 			"valid_from": "2017-01-01",
-			"plan_guid": "957e6177-323c-4eeb-8630-c4bfa979a86c",
+			"plan_guid": "3a51701c-eef3-447c-882b-907ad2bcb7ab",
 			"number_of_nodes": 1,
 			"components": [
 				{
@@ -857,7 +857,7 @@
 		{
 			"name": "redis tiny-unclustered-3.2",
 			"valid_from": "2017-01-01",
-			"plan_guid": "ffa2f099-e416-4632-b936-32ab0c0c0166",
+			"plan_guid": "c84d1bef-9500-4ce9-88b2-c0bd421bbf8a",
 			"number_of_nodes": 1,
 			"components": [
 				{
@@ -871,7 +871,7 @@
 		{
 			"name": "cloudfront cdn-route",
 			"valid_from": "2017-01-01",
-			"plan_guid": "e4f39630-e385-410b-972f-6b4cc7aad112",
+			"plan_guid": "fc055c72-1075-44c9-9aee-bddd52e1b053",
 			"components": [
 				{
 					"name": "distribution",
@@ -884,7 +884,7 @@
 		{
 			"name": "mongodb tiny (compose)",
 			"valid_from": "2017-01-01",
-			"plan_guid": "5d56dd1b-52d5-4ffb-a034-fc5c79794c90",
+			"plan_guid": "fdfd4fc1-ce69-451c-a436-c2e2795b9abe",
 			"memory_in_mb": 1024,
 			"components": [
 				{
@@ -912,7 +912,7 @@
 		{
 			"name": "elasticsearch tiny (compose)",
 			"valid_from": "2017-01-01",
-			"plan_guid": "31bb8b32-d5e0-4310-8a8d-3e8bff4b2bbc",
+			"plan_guid": "6d051078-0913-403c-9763-1d03ecee50d9",
 			"memory_in_mb": 2048,
 			"components": [
 				{
@@ -926,7 +926,7 @@
 		{
 			"name": "elasticsearch small-ha-5.x",
 			"valid_from": "2017-01-01",
-			"plan_guid": "6c35a479-9622-4852-b80e-b21b40e0378f",
+			"plan_guid": "0eee9e10-db37-4cc3-bc9b-39e378ff3a5f",
 			"components": [
 				{
 					"name": "instance",
@@ -939,7 +939,7 @@
 		{
 			"name": "elasticsearch small-ha-6.x",
 			"valid_from": "2017-01-01",
-			"plan_guid": "99c6c41e-5f7a-4422-a7f2-95e7d8f88b30",
+			"plan_guid": "225e97cc-f786-408c-8b59-d2118248a53d",
 			"components": [
 				{
 					"name": "instance",

--- a/config.json
+++ b/config.json
@@ -33,33 +33,46 @@
 		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
+			"plan_guid": "cc65268f-98e9-40ef-aa8c-8e595204064d",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "0",
+					"currency_code": "GBP",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "prometheus",
+			"valid_from": "2017-01-01",
+			"plan_guid": "7ab58e11-3959-49b4-9218-807e3e78f9af",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "0",
+					"currency_code": "GBP",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "prometheus",
+			"valid_from": "2017-01-01",
+			"plan_guid": "01889e73-78b3-41d9-b29e-71d6ccfc8821",
+			"components": [
+				{
+					"name": "instance",
+					"formula": "0",
+					"currency_code": "GBP",
+					"vat_code": "Standard"
+				}
+			]
+		},
+		{
+			"name": "prometheus",
+			"valid_from": "2017-01-01",
 			"plan_guid": "b5998c91-d379-4df7-b329-11450f8459f1",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "0",
-					"currency_code": "GBP",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
-			"name": "prometheus",
-			"valid_from": "2017-01-01",
-			"plan_guid": "9befba08-c364-4d50-83d1-955b84a69989",
-			"components": [
-				{
-					"name": "instance",
-					"formula": "0",
-					"currency_code": "GBP",
-					"vat_code": "Standard"
-				}
-			]
-		},
-		{
-			"name": "prometheus",
-			"valid_from": "2017-01-01",
-			"plan_guid": "329d4411-e2e1-4e10-873a-b80d966d522a",
 			"components": [
 				{
 					"name": "instance",

--- a/config.json
+++ b/config.json
@@ -31,6 +31,19 @@
 	"ignore_missing_plans": true,
 	"pricing_plans": [
 		{
+			"name": "unknown-plan",
+			"valid_from": "1970-01-01",
+			"plan_guid": "d5091c33-2f9d-4b15-82dc-4ad69717fc03",
+			"components": [
+				{
+					"name": "unknown",
+					"formula": "0",
+					"currency_code": "GBP",
+					"vat_code": "Zero"
+				}
+			]
+		},
+		{
 			"name": "prometheus",
 			"valid_from": "2017-01-01",
 			"plan_guid": "cc65268f-98e9-40ef-aa8c-8e595204064d",

--- a/config.json
+++ b/config.json
@@ -911,7 +911,7 @@
 		{
 			"name": "redis tiny (compose)",
 			"valid_from": "2017-01-01",
-			"plan_guid": "53ca5c56-5474-4d64-9211-fe9aee86d502",
+			"plan_guid": "a8574a4b-9c6c-40ea-a0df-e9b7507948c8",
 			"memory_in_mb": 256,
 			"components": [
 				{

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -274,7 +274,8 @@ INSERT INTO events with
 		coalesce(vspace.name, space_guid::text) as space_name,
 		duration,
 		(case
-			when resource_type = 'service' then vsp.unique_id::uuid
+			when resource_type = 'service'
+			then coalesce(vsp.unique_id, 'd5091c33-2f9d-4b15-82dc-4ad69717fc03')::uuid
 			else plan_guid
 		end) as plan_guid,
 		coalesce(vsp.name, plan_name) as plan_name,

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -273,7 +273,10 @@ INSERT INTO events with
 		space_guid,
 		coalesce(vspace.name, space_guid::text) as space_name,
 		duration,
-		plan_guid,
+		(case
+			when resource_type = 'service' then vsp.unique_id::uuid
+			else plan_guid
+		end) as plan_guid,
 		coalesce(vsp.name, plan_name) as plan_name,
 		coalesce(vs.guid, ev.service_guid) as service_guid,
 		coalesce(vs.label, ev.service_name) as service_name,

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -490,7 +490,7 @@ func checkCurrencyRates(tx *sql.Tx) error {
 			pricing_plan_components ppc
 		where
 			ppc.currency_code not in (
-				select code 
+				select code
 				from currency_rates cr
 				where cr.valid_from <= ppc.valid_from
 			)
@@ -513,16 +513,30 @@ func checkCurrencyRates(tx *sql.Tx) error {
 }
 
 // generateMissingPlans creates dummy plans with 0 cost at the epoch time
-// useful for getting the system up with an existing dataset without configuring it properly
+// for every single plan in events, unless there is already one.
+// Useful for getting the system up with an existing dataset without
+// configuring it properly
 func (s *EventStore) generateMissingPlans(tx *sql.Tx) error {
 	rows, err := tx.Query(`
 		insert into pricing_plans (
 			plan_guid, valid_from, name
-		) (select distinct
-			plan_guid,
-			'epoch'::timestamptz,
-			first_value(resource_type || ' ' || plan_name) over (partition by plan_guid order by lower(duration) desc)
-		from events)
+		) (
+			select
+				distinct plan_guid,
+				'epoch'::timestamptz,
+				first_value(resource_type || ' ' || plan_name)
+				over (
+					partition by plan_guid
+					order by lower(duration) desc
+				)
+			from events
+			where plan_guid not in (
+				select distinct plan_guid
+				from pricing_plans pp
+				where pp.plan_guid = events.plan_guid
+				and valid_from = 'epoch'::timestamptz
+			)
+		)
 		returning plan_guid, name
 	`)
 	if err != nil {
@@ -546,15 +560,23 @@ func (s *EventStore) generateMissingPlans(tx *sql.Tx) error {
 	if _, err := tx.Exec(`
 		insert into pricing_plan_components (
 			plan_guid, valid_from, name, formula, vat_code, currency_code
-		) select distinct
-			plan_guid,
-			'epoch'::timestamptz,
-			'pending',
-			'0',
-			'Standard'::vat_code,
-			'GBP'::currency_code
-		from events
-	`); err != nil {
+		) (
+			select distinct
+				plan_guid,
+				'epoch'::timestamptz,
+				'pending',
+				'0',
+				'Standard'::vat_code,
+				'GBP'::currency_code
+			from events
+			where plan_guid not in (
+				select distinct plan_guid
+				from pricing_plan_components ppc
+				where ppc.plan_guid = events.plan_guid
+				and valid_from = 'epoch'::timestamptz
+			)
+		)`,
+	); err != nil {
 		return wrapPqError(err, "generate-service-plan-component")
 	}
 	return nil
@@ -611,7 +633,7 @@ func checkPlanConsistency(tx *sql.Tx) error {
 				pricing_plans
 		)
 		select distinct
-			plan_guid,	
+			plan_guid,
 			plan_name,
 			resource_type
 		from

--- a/eventstore/store_billable_events_test.go
+++ b/eventstore/store_billable_events_test.go
@@ -1004,7 +1004,7 @@ var _ = Describe("GetBillableEvents", func() {
 			ValidFrom: "epoch",
 		})
 		plan := eventio.PricingPlan{
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom:     "2001-01-01",
 			Name:          "PLAN1",
 			NumberOfNodes: 1,
@@ -1024,6 +1024,36 @@ var _ = Describe("GetBillableEvents", func() {
 		db, err := testenv.Open(cfg)
 		Expect(err).ToNot(HaveOccurred())
 		defer db.Close()
+
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "postgres",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "Free",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
 
 		service1EventStart := testenv.Row{
 			"guid":        "00000000-0000-0000-0000-000000000001",
@@ -1078,7 +1108,7 @@ var _ = Describe("GetBillableEvents", func() {
 			OrgName:       "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:     "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:     "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			NumberOfNodes: 1,
 			MemoryInMB:    1024,
 			StorageInMB:   2048,
@@ -1113,7 +1143,7 @@ var _ = Describe("GetBillableEvents", func() {
 			OrgName:       "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:     "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:     "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			NumberOfNodes: 1,
 			MemoryInMB:    2048,
 			StorageInMB:   4096,

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -193,6 +193,265 @@ var _ = Describe("Store", func() {
 		Expect(db.Get(`SELECT COUNT(*) FROM billable_event_components`)).To(BeNumerically("==", 1))
 	})
 
+	It("should fail if there is a service_plan without pricing_plan", func() {
+		db, err := testenv.Open(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		defer db.Close()
+		store := db.Schema
+
+		Expect(db.Insert("services", testenv.Row{
+			"guid":                "6c3d1a25-0fbc-45e5-9076-d940390a3bc0",
+			"valid_from":          "2000-01-01T00:00:00Z",
+			"created_at":          "2000-01-01T00:00:00Z",
+			"updated_at":          "2018-06-14T16:32:38Z",
+			"label":               "AWESOME_SERVICE_NAME",
+			"description":         "the test service service",
+			"active":              true,
+			"bindable":            true,
+			"service_broker_guid": "879d7b06-642d-4bf6-b5e8-1a52451c849a",
+		})).To(Succeed())
+
+		Expect(db.Insert("service_plans", testenv.Row{
+			"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			"valid_from":         "2000-01-01T00:00:00Z",
+			"created_at":         "2000-01-01T00:00:00Z",
+			"updated_at":         "2018-06-14T16:32:38Z",
+			"name":               "AWESOME_SERVICE_PLAN_NAME",
+			"description":        "the test service service",
+			"service_guid":       "6c3d1a25-0fbc-45e5-9076-d940390a3bc0",
+			"service_valid_from": "2000-01-01T00:00:00Z",
+			"unique_id":          "c6221308-b7bb-46d2-9d79-a357f5a3837b",
+			"active":             true,
+			"public":             true,
+			"free":               false,
+			"extra":              "",
+		})).To(Succeed())
+
+		service1EventStart := eventio.RawEvent{
+			GUID:      "c497eb13-f48a-4859-be53-5569f302b516",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "CREATED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"service_plan_name": "Free",
+				"service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f",
+				"service_instance_name": "DB1",
+				"service_instance_type": "managed_service_instance"
+			}`),
+		}
+		service1EventStop := eventio.RawEvent{
+			GUID:      "dd52b4f4-9e33-4504-8fca-fd9e33af11a6",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 1, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "DELETED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"service_plan_name": "Free",
+				"service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f",
+				"service_instance_name": "DB1",
+				"service_instance_type": "managed_service_instance"
+			}`),
+		}
+
+		Expect(store.StoreEvents([]eventio.RawEvent{
+			service1EventStart,
+			service1EventStop,
+		})).To(Succeed())
+
+		err = store.Refresh()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(`missing 'service' pricing plan configuration for 'AWESOME_SERVICE_PLAN_NAME' (c6221308-b7bb-46d2-9d79-a357f5a3837b)`))
+	})
+
+	It("should not fail and generate a fake plan if there is a service_plan without pricing_plan but IgnoreMissingPlans=true", func() {
+		cfg.IgnoreMissingPlans = true
+
+		existingPlan := eventio.PricingPlan{
+			PlanGUID:  "c6221308-b7bb-46d2-9d79-a357f5a3837b",
+			ValidFrom: "1970-01-01T00:00:00+00:00",
+			Name:      "AWESOME_SERVICE_PLAN_NAME",
+			Components: []eventio.PricingPlanComponent{
+				{
+					Name:         "compute",
+					Formula:      "ceil($time_in_seconds/3600) * 1",
+					CurrencyCode: "GBP",
+					VATCode:      "Standard",
+				},
+			},
+		}
+		cfg.AddPlan(existingPlan)
+
+		db, err := testenv.Open(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		defer db.Close()
+		store := db.Schema
+
+		Expect(db.Insert("services", testenv.Row{
+			"guid":                "6c3d1a25-0fbc-45e5-9076-d940390a3bc0",
+			"valid_from":          "2000-01-01T00:00:00Z",
+			"created_at":          "2000-01-01T00:00:00Z",
+			"updated_at":          "2018-06-14T16:32:38Z",
+			"label":               "AWESOME_SERVICE_NAME",
+			"description":         "the test service service",
+			"active":              true,
+			"bindable":            true,
+			"service_broker_guid": "879d7b06-642d-4bf6-b5e8-1a52451c849a",
+		})).To(Succeed())
+
+		Expect(db.Insert("service_plans", testenv.Row{
+			"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			"valid_from":         "2000-01-01T00:00:00Z",
+			"created_at":         "2000-01-01T00:00:00Z",
+			"updated_at":         "2018-06-14T16:32:38Z",
+			"name":               "AWESOME_SERVICE_PLAN_NAME",
+			"description":        "the test service service",
+			"service_guid":       "6c3d1a25-0fbc-45e5-9076-d940390a3bc0",
+			"service_valid_from": "2000-01-01T00:00:00Z",
+			"unique_id":          "c6221308-b7bb-46d2-9d79-a357f5a3837b",
+			"active":             true,
+			"public":             true,
+			"free":               false,
+			"extra":              "",
+		})).To(Succeed())
+
+		Expect(db.Insert("service_plans", testenv.Row{
+			"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe6",
+			"valid_from":         "2000-01-01T00:00:00Z",
+			"created_at":         "2000-01-01T00:00:00Z",
+			"updated_at":         "2018-06-14T16:32:38Z",
+			"name":               "AWESOME_MISSING_SERVICE_PLAN_NAME",
+			"description":        "the missing test service service",
+			"service_guid":       "6c3d1a25-0fbc-45e5-9076-d940390a3bc0",
+			"service_valid_from": "2000-01-01T00:00:00Z",
+			"unique_id":          "cccccccc-cccc-cccc-cccc-cccccccccccc",
+			"active":             true,
+			"public":             true,
+			"free":               false,
+			"extra":              "",
+		})).To(Succeed())
+
+		service1EventStart := eventio.RawEvent{
+			GUID:      "c497eb13-f48a-4859-be53-5569f302b516",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "CREATED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"service_plan_name": "AWESOME_SERVICE_PLAN_NAME",
+				"service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f",
+				"service_instance_name": "DB1",
+				"service_instance_type": "managed_service_instance"
+			}`),
+		}
+		service1EventStop := eventio.RawEvent{
+			GUID:      "dd52b4f4-9e33-4504-8fca-fd9e33af11a6",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 1, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "DELETED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"service_plan_name": "AWESOME_SERVICE_PLAN_NAME",
+				"service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f",
+				"service_instance_name": "DB1",
+				"service_instance_type": "managed_service_instance"
+			}`),
+		}
+
+		service2EventStart := eventio.RawEvent{
+			GUID:      "c497eb13-f48a-4859-be53-5569f302b517",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "CREATED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe6",
+				"service_plan_name": "AWESOME_MISSING_SERVICE_PLAN_NAME",
+				"service_instance_guid": "6f4e0958-e87e-4880-aa28-9babe7be0512",
+				"service_instance_name": "DB2",
+				"service_instance_type": "managed_service_instance"
+			}`),
+		}
+		service2EventStop := eventio.RawEvent{
+			GUID:      "dd52b4f4-9e33-4504-8fca-fd9e33af11a7",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 1, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "DELETED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe6",
+				"service_plan_name": "AWESOME_MISSING_SERVICE_PLAN_NAME",
+				"service_instance_guid": "6f4e0958-e87e-4880-aa28-9babe7be0512",
+				"service_instance_name": "DB2",
+				"service_instance_type": "managed_service_instance"
+			}`),
+		}
+
+		Expect(store.StoreEvents([]eventio.RawEvent{
+			service1EventStart,
+			service1EventStop,
+			service2EventStart,
+			service2EventStop,
+		})).To(Succeed())
+
+		err = store.Refresh()
+		Expect(err).ToNot(HaveOccurred())
+
+		plans, err := store.GetPricingPlans(eventio.PricingPlanFilter{
+			RangeStart: "2001-01-01",
+			RangeStop:  "2002-01-01",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(plans).To(HaveLen(2))
+		Expect(plans[0]).To(Equal(existingPlan))
+		Expect(plans[1]).To(Equal(
+			eventio.PricingPlan{
+				PlanGUID:      "cccccccc-cccc-cccc-cccc-cccccccccccc",
+				ValidFrom:     "1970-01-01T00:00:00+00:00",
+				Name:          "service AWESOME_MISSING_SERVICE_PLAN_NAME",
+				NumberOfNodes: 0,
+				MemoryInMB:    0,
+				StorageInMB:   0,
+				Components: []eventio.PricingPlanComponent{
+					{
+						Name:         "pending",
+						Formula:      "0",
+						CurrencyCode: "GBP",
+						VATCode:      "Standard",
+					},
+				},
+			},
+		))
+	})
+
 	It("should ensure plan has unique plan_guid + valid_from", func() {
 		cfg.AddPlan(eventio.PricingPlan{
 			PlanGUID:  eventstore.ComputePlanGUID,

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Store", func() {
 			},
 		})
 		cfg.AddPlan(eventio.PricingPlan{
-			PlanGUID:  "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom: "2001-01-01",
 			Name:      "DB_PLAN_1",
 			Components: []eventio.PricingPlanComponent{
@@ -85,6 +85,36 @@ var _ = Describe("Store", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer db.Close()
 
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "postgres",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "Free",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
+
 		Expect(db.Insert("app_usage_events", app1EventStart, app1EventStop)).To(Succeed())
 		Expect(db.Insert("service_usage_events", service1EventStart, service1EventStop)).To(Succeed())
 		Expect(db.Schema.Refresh()).To(Succeed())
@@ -99,7 +129,7 @@ var _ = Describe("Store", func() {
 				"number_of_nodes": nil,
 				"org_guid":        "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 				"org_name":        "51ba75ef-edc0-47ad-a633-a8f6e8770944",
-				"plan_guid":       "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"plan_guid":       "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				"plan_name":       "Free",
 				"service_guid":    "efadb775-58c4-4e17-8087-6d0f4febc489",
 				"service_name":    "postgres",

--- a/eventstore/store_usage_events_test.go
+++ b/eventstore/store_usage_events_test.go
@@ -62,7 +62,7 @@ var _ = Describe("GetUsageEvents", func() {
 			},
 		})
 		cfg.AddPlan(eventio.PricingPlan{
-			PlanGUID:  "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom: "2001-01-01",
 			Name:      "DB_PLAN_1",
 			Components: []eventio.PricingPlanComponent{
@@ -122,6 +122,36 @@ var _ = Describe("GetUsageEvents", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer db.Close()
 		store := db.Schema
+
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "postgres",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "Free",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
 
 		Expect(store.StoreEvents([]eventio.RawEvent{
 			app1EventBuildpackSet,
@@ -192,7 +222,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:       "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
 			SpaceName:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:      "Free",
 			ServiceGUID:   "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:   "postgres",
@@ -221,7 +251,7 @@ var _ = Describe("GetUsageEvents", func() {
 			ValidFrom: "epoch",
 		})
 		plan := eventio.PricingPlan{
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom:     "2001-01-01",
 			Name:          "PLAN1",
 			NumberOfNodes: 1,
@@ -241,6 +271,36 @@ var _ = Describe("GetUsageEvents", func() {
 		db, err := testenv.Open(cfg)
 		Expect(err).ToNot(HaveOccurred())
 		defer db.Close()
+
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "compose-db",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "PLAN1",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
 
 		service1EventStart := testenv.Row{
 			"guid":        "00000000-0000-0000-0000-000000000001",
@@ -290,7 +350,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:     "PLAN1",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "compose-db",
@@ -308,7 +368,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:     "PLAN1",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "compose-db",
@@ -326,7 +386,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:     "PLAN1",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "compose-db",
@@ -346,7 +406,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:     "PLAN1",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "compose-db",
@@ -373,7 +433,7 @@ var _ = Describe("GetUsageEvents", func() {
 			ValidFrom: "epoch",
 		})
 		plan1 := eventio.PricingPlan{
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-000000000001",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom:     "2001-01-01",
 			Name:          "PLAN1",
 			NumberOfNodes: 1,
@@ -389,7 +449,7 @@ var _ = Describe("GetUsageEvents", func() {
 			},
 		}
 		plan2 := eventio.PricingPlan{
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-000000000002",
+			PlanGUID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
 			ValidFrom:     "2001-01-01",
 			Name:          "PLAN2",
 			NumberOfNodes: 1,
@@ -410,6 +470,53 @@ var _ = Describe("GetUsageEvents", func() {
 		db, err := testenv.Open(cfg)
 		Expect(err).ToNot(HaveOccurred())
 		defer db.Close()
+
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "postgres",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "PLAN1",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-000000000001",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+				"name":               "PLAN2",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-000000000002",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
 
 		service1EventStart := testenv.Row{
 			"guid":        "00000000-0000-0000-0000-000000000001",
@@ -449,7 +556,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-000000000001",
+			PlanGUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:     "PLAN1",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "postgres",
@@ -466,7 +573,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-000000000002",
+			PlanGUID:     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
 			PlanName:     "PLAN2",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "postgres",
@@ -492,7 +599,7 @@ var _ = Describe("GetUsageEvents", func() {
 			ValidFrom: "epoch",
 		})
 		plan := eventio.PricingPlan{
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom:     "2001-01-01",
 			Name:          "PLAN1",
 			NumberOfNodes: 1,
@@ -512,6 +619,36 @@ var _ = Describe("GetUsageEvents", func() {
 		db, err := testenv.Open(cfg)
 		Expect(err).ToNot(HaveOccurred())
 		defer db.Close()
+
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "compose-db",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "PLAN1",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
 
 		service1EventScale := testenv.Row{
 			"event_id":    "audit-id-000000000003",
@@ -554,7 +691,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:     "PLAN1",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "compose-db",
@@ -573,7 +710,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:      "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:    "276f4886-ac40-492d-a8cd-b2646637ba76",
 			SpaceName:    "276f4886-ac40-492d-a8cd-b2646637ba76",
-			PlanGUID:     "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:     "PLAN1",
 			ServiceGUID:  "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:  "compose-db",
@@ -596,7 +733,7 @@ var _ = Describe("GetUsageEvents", func() {
 	*-----------------------------------------------------------------------------------*/
 	It("should use the service_name from the historic service/service_plans data if available", func() {
 		cfg.AddPlan(eventio.PricingPlan{
-			PlanGUID:  "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:  "c6221308-b7bb-46d2-9d79-a357f5a3837b",
 			ValidFrom: "2001-01-01",
 			Name:      "DB_PLAN_1",
 			Components: []eventio.PricingPlanComponent{
@@ -610,16 +747,40 @@ var _ = Describe("GetUsageEvents", func() {
 		})
 
 		service1EventStart := eventio.RawEvent{
-			GUID:       "c497eb13-f48a-4859-be53-5569f302b516",
-			Kind:       "service",
-			CreatedAt:  time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
-			RawMessage: json.RawMessage(`{"state": "CREATED", "org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944", "space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d", "space_name": "sandbox", "service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489", "service_label": "postgres", "service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5", "service_plan_name": "Free", "service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f", "service_instance_name": "DB1", "service_instance_type": "managed_service_instance"}`),
+			GUID:      "c497eb13-f48a-4859-be53-5569f302b516",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "CREATED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"service_plan_name": "Free",
+				"service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f",
+				"service_instance_name": "DB1",
+				"service_instance_type": "managed_service_instance"
+			}`),
 		}
 		service1EventStop := eventio.RawEvent{
-			GUID:       "dd52b4f4-9e33-4504-8fca-fd9e33af11a6",
-			Kind:       "service",
-			CreatedAt:  time.Date(2001, 1, 1, 1, 0, 0, 0, time.UTC),
-			RawMessage: json.RawMessage(`{"state": "DELETED", "org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944", "space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d", "space_name": "sandbox", "service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489", "service_label": "postgres", "service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5", "service_plan_name": "Free", "service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f", "service_instance_name": "DB1", "service_instance_type": "managed_service_instance"}`),
+			GUID:      "dd52b4f4-9e33-4504-8fca-fd9e33af11a6",
+			Kind:      "service",
+			CreatedAt: time.Date(2001, 1, 1, 1, 0, 0, 0, time.UTC),
+			RawMessage: json.RawMessage(`{
+				"state": "DELETED",
+				"org_guid": "51ba75ef-edc0-47ad-a633-a8f6e8770944",
+				"space_guid": "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
+				"space_name": "sandbox",
+				"service_guid": "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_label": "postgres",
+				"service_plan_guid": "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"service_plan_name": "Free",
+				"service_instance_guid": "f3f98365-6a95-4bbd-ab8f-527a7957a41f",
+				"service_instance_name": "DB1",
+				"service_instance_type": "managed_service_instance"
+			}`),
 		}
 
 		db, err := testenv.Open(cfg)
@@ -680,7 +841,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:       "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
 			SpaceName:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "c6221308-b7bb-46d2-9d79-a357f5a3837b",
 			PlanName:      "AWESOME_SERVICE_PLAN_NAME",
 			ServiceGUID:   "6c3d1a25-0fbc-45e5-9076-d940390a3bc0",
 			ServiceName:   "AWESOME_SERVICE_NAME",
@@ -704,7 +865,7 @@ var _ = Describe("GetUsageEvents", func() {
 	*-----------------------------------------------------------------------------------*/
 	It("should use the org name from the historic data if available", func() {
 		cfg.AddPlan(eventio.PricingPlan{
-			PlanGUID:  "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom: "2001-01-01",
 			Name:      "DB_PLAN_1",
 			Components: []eventio.PricingPlanComponent{
@@ -734,6 +895,36 @@ var _ = Describe("GetUsageEvents", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer db.Close()
 		store := db.Schema
+
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "postgres",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "Free",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
 
 		Expect(db.Insert("orgs", testenv.Row{
 			"guid":                  "51ba75ef-edc0-47ad-a633-a8f6e8770944",
@@ -769,7 +960,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:       "my-org",
 			SpaceGUID:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
 			SpaceName:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:      "Free",
 			ServiceGUID:   "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:   "postgres",
@@ -781,7 +972,7 @@ var _ = Describe("GetUsageEvents", func() {
 
 	It("should use the org guid if the org name is not available", func() {
 		cfg.AddPlan(eventio.PricingPlan{
-			PlanGUID:  "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			ValidFrom: "2001-01-01",
 			Name:      "DB_PLAN_1",
 			Components: []eventio.PricingPlanComponent{
@@ -812,6 +1003,36 @@ var _ = Describe("GetUsageEvents", func() {
 		defer db.Close()
 		store := db.Schema
 
+		Expect(db.Insert("services",
+			testenv.Row{
+				"label":               "postgres",
+				"guid":                "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"valid_from":          "2000-01-01T00:00Z",
+				"created_at":          "2000-01-01T00:00Z",
+				"updated_at":          "2000-01-01T00:00Z",
+				"description":         "",
+				"service_broker_guid": "efadb775-58c4-4e17-8087-6d0f4febc481",
+				"active":              true,
+				"bindable":            true,
+			})).To(Succeed())
+
+		Expect(db.Insert("service_plans",
+			testenv.Row{
+				"unique_id":          "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				"name":               "Free",
+				"guid":               "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+				"valid_from":         "2000-01-01T00:00Z",
+				"created_at":         "2000-01-01T00:00Z",
+				"updated_at":         "2000-01-01T00:00Z",
+				"description":        "",
+				"service_guid":       "efadb775-58c4-4e17-8087-6d0f4febc489",
+				"service_valid_from": "2000-01-01T00:00Z",
+				"active":             true,
+				"public":             true,
+				"free":               true,
+				"extra":              "",
+			})).To(Succeed())
+
 		Expect(store.StoreEvents([]eventio.RawEvent{
 			service1EventStart,
 			service1EventStop,
@@ -837,7 +1058,7 @@ var _ = Describe("GetUsageEvents", func() {
 			OrgName:       "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			SpaceGUID:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
 			SpaceName:     "bd405d91-0b7c-4b8c-96ef-8b4c1e26e75d",
-			PlanGUID:      "efb5f1ce-0a8a-435d-a8b2-6b2b61c6dbe5",
+			PlanGUID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			PlanName:      "Free",
 			ServiceGUID:   "efadb775-58c4-4e17-8087-6d0f4febc489",
 			ServiceName:   "postgres",

--- a/scripts/create_adhoc_redis_service.sql
+++ b/scripts/create_adhoc_redis_service.sql
@@ -1,0 +1,73 @@
+-- Add the missing historic recorded service in prod
+--
+--  redis tiny (compose)
+--
+-- Some events refer to this service plan with GUID:
+--
+--  53ca5c56-5474-4d64-9211-fe9aee86d502
+--
+INSERT INTO services (
+	guid,
+	valid_from,
+	created_at,
+	updated_at,
+	label,
+	description,
+	active,
+	bindable,
+	service_broker_guid
+) (
+    SELECT
+        '2e5bc51e-b210-41e1-b0b7-e0ae5566c801'::uuid,
+        '2016-01-01T00:00:00+00:00'::timestamptz,
+        '2016-01-01T00:00:00+00:00'::timestamptz,
+        '2016-01-01T00:00:00+00:00'::timestamptz,
+        'redis-compose',
+        'Redis instance',
+        false,
+        false,
+        '30b034f9-1eb0-4a44-8f16-d4d76baba415'::uuid
+    WHERE
+        '2e5bc51e-b210-41e1-b0b7-e0ae5566c801'::uuid NOT IN (
+            SELECT DISTINCT guid FROM services
+        )
+);
+
+INSERT INTO service_plans (
+    guid,
+    valid_from,
+    created_at,
+    updated_at,
+    name,
+    description,
+    unique_id,
+    service_guid,
+    service_valid_from,
+    active,
+    public,
+    free,
+    extra
+) (
+    SELECT
+        -- Old GUID in the existing events in prod
+        '53ca5c56-5474-4d64-9211-fe9aee86d502'::uuid,
+        '2016-01-01T00:00:00+00:00'::timestamptz,
+        '2016-01-01T00:00:00+00:00'::timestamptz,
+        '2016-01-01T00:00:00+00:00'::timestamptz,
+        'redis tiny (compose)',
+        'redis tiny (compose)',
+        -- new unique ID we want to match
+        'a8574a4b-9c6c-40ea-a0df-e9b7507948c8'::uuid,
+        -- service.guid from above
+        '2e5bc51e-b210-41e1-b0b7-e0ae5566c801'::uuid,
+        '2016-01-01T00:00:00+00:00'::timestamptz,
+        false,
+        false,
+        false,
+        ''
+    WHERE
+        '53ca5c56-5474-4d64-9211-fe9aee86d502'::uuid NOT IN (
+            SELECT DISTINCT guid FROM service_plans
+        )
+);
+


### PR DESCRIPTION
What
----

This PR is the second one after closing #49

This PR changes how we map the service plans for billing purposes with the events.

Currently we were using the Cloud Foundry generated `service_plan_guid` for this purpose. This had the limitation that different CF deployments would require different pricing_plans with a different plan_guid.

Since we did the work to collect the historic data in https://github.com/alphagov/paas-billing/pull/36 we have the broker reported plan unique IDs available for this purpose.

This PR would leverage the table `service_plans` to map the events to the corresponding plans using the plan unique ID reported by the broker. It also updates the embedded `config.json` to use the `unique_id` stored in the `service_plans` table instead of the specific CF plan id.

Notes about the implementation:

 - Old Pricing Calculator URLs would break:
    - We change the `config.json` IDs, which means that the `/pricing_plans` would report a different GUID for the plans.
   - The forecast events would use this new `unique_id` when passing the value of `plan_guid`. This makes sense as the `/pricing_plans` where `paas-admin` calculator gets the values would be using `uinque_ids`.

 - We add some additional tests to cover this case
 - We add logic to map any service not stored in the historic tables `services` and `service_plans` to a "Unknown Plan" with cost 0.
 - **IMPORTANT** We added a SQL script to add a missing service plan for `redis tiny (compose)`.


How to review
-----

- Code review
- Deploy https://github.com/alphagov/paas-cf/pull/1502
- Check you have bills for services in your dev env, admin is a good org to test with.

Optionally testing in prod data (requires access to prod):
 - We did compare all the costs calculated with this version for all the orgs in prod.
 - All the notes are in the private HackMD of the story. The scripts are documented in a comment in https://github.com/alphagov/paas-billing/pull/49#issuecomment-417677182

Before merge
----------------

It is important to run the script: `scripts/create_adhoc_redis_service.sql` in prod before deploying in prod:

```
cf login -a https://api.cloud.service.gov.uk --sso
cf target -o admin -s billing
cf conduit billing-db -- psql
```
and paste the script.

Who can review
-----

Not @LeePorte or @keymon