### PR TITLE
[#161316533] Split the API server and event collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,22 @@ You will need:
 
 * `Go v1.9+`
 
-To build the application run:
+To build the application run the default make target:
 
 ```
 make
 ```
 
 You should then get a binary in `bin/paas-billing`.
+
+The application has two commands to run the following components:
+ - **api**: Runs the tenant-facing API server which can be scaled to any number of instances. Only queries the database.
+ - **collector**: Runs all the processes to regularly collect usage information and produce billing data. There should be no multiple instances running.
+
+E.g. to run the API you should use the following command:
+```
+./bin/paas-billing api
+```
 
 ## Configuration
 
@@ -483,13 +492,20 @@ You will need:
 * The aws cli tools and relevent keys
 * A paas-cf dev environment
 
-Use the provided `run-dev` make target to run the application and connect it to a development instance of paas-cf:
+Use the provided `run-dev` make target to run all application components and connect it to a development instance of paas-cf:
 
 ```
 make run-dev
 ```
 
 The task will extract the necessary secrets for Cloud Foundry and set up the important environment variables.
+
+If you want to run the application components separately, then you should use the appropriate make targets:
+
+```
+make run-dev-api
+make run-dev-collector
+```
 
 ### Run the tests
 
@@ -501,7 +517,8 @@ make test
 
 If you have a development environment setup that works with `run-dev` you can run a basic smoke test against it via:
 
+**BROKEN** Currently the smoke tests are broken.
+
 ```
 make smoke
 ```
-

--- a/eventserver/server_auth.go
+++ b/eventserver/server_auth.go
@@ -25,7 +25,7 @@ func authorize(c echo.Context, uaa auth.Authenticator, orgs []string) (bool, err
 
 	isAdmin, err := authorizer.Admin()
 	if err != nil {
-		return false, fmt.Errorf("invalid credentials", err)
+		return false, fmt.Errorf("invalid credentials: %s", err)
 	}
 	if isAdmin {
 		return true, nil
@@ -33,7 +33,7 @@ func authorize(c echo.Context, uaa auth.Authenticator, orgs []string) (bool, err
 
 	hasBillingAccess, err := authorizer.HasBillingAccess(orgs)
 	if err != nil {
-		return false, fmt.Errorf("invalid credentials", err)
+		return false, fmt.Errorf("invalid credentials: %s", err)
 	}
 	if hasBillingAccess {
 		return true, nil

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -85,23 +87,38 @@ func cfDataCollector(databaseUrl string, logger lager.Logger) error {
 }
 
 func Main(logger lager.Logger) error {
+
 	cfg, err := NewConfigFromEnv()
 	if err != nil {
 		return err
 	}
 	cfg.Logger = logger
 
-	cfDataCollector(cfg.DatabaseURL, cfg.Logger)
-
 	app, err := New(globalContext, cfg)
 	if err != nil {
 		return err
 	}
 
+	if len(os.Args) < 2 {
+		return errors.New("Please provide a command to run [api | collector]")
+	}
+	switch command := os.Args[1]; command {
+	case "collector":
+		return startCollector(app, cfg)
+	case "api":
+		return startAPI(app, cfg)
+	default:
+		return fmt.Errorf("Subcommand %s not recognised", command)
+	}
+}
+
+func startCollector(app *App, cfg Config) error {
+
+	cfDataCollector(cfg.DatabaseURL, cfg.Logger)
+
 	if err := app.Init(); err != nil {
 		return err
 	}
-
 	if err := app.StartAppEventCollector(); err != nil {
 		return err
 	}
@@ -113,16 +130,19 @@ func Main(logger lager.Logger) error {
 	if err := app.StartEventProcessor(); err != nil {
 		return err
 	}
-
-	if err := app.StartEventServer(); err != nil {
-		return err
-	}
-
 	if err := app.StartHistoricDataCollector(); err != nil {
 		return err
 	}
 
-	logger.Info("started")
+	cfg.Logger.Info("started collector")
+	return app.Wait()
+}
+
+func startAPI(app *App, cfg Config) error {
+	if err := app.StartEventServer(); err != nil {
+		return err
+	}
+	cfg.Logger.Info("started API")
 	return app.Wait()
 }
 

--- a/main.go
+++ b/main.go
@@ -17,20 +17,6 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
-var globalContext context.Context
-
-func init() {
-	ctx, shutdown := context.WithCancel(context.Background())
-	globalContext = ctx
-	go func() {
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-		defer signal.Reset(syscall.SIGINT, syscall.SIGTERM)
-		<-sigChan
-		shutdown()
-	}()
-}
-
 func cfDataCollector(databaseUrl string, logger lager.Logger) error {
 	client, err := cfclient.NewClient(&cfclient.Config{
 		ApiAddress:        os.Getenv("CF_API_ADDRESS"),
@@ -86,7 +72,7 @@ func cfDataCollector(databaseUrl string, logger lager.Logger) error {
 	return nil
 }
 
-func Main(logger lager.Logger) error {
+func Main(ctx context.Context, logger lager.Logger) error {
 
 	cfg, err := NewConfigFromEnv()
 	if err != nil {
@@ -94,7 +80,7 @@ func Main(logger lager.Logger) error {
 	}
 	cfg.Logger = logger
 
-	app, err := New(globalContext, cfg)
+	app, err := New(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -147,10 +133,20 @@ func startAPI(app *App, cfg Config) error {
 }
 
 func main() {
+	ctx, shutdown := context.WithCancel(context.Background())
+
+	go func() {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+		<-sigChan
+		shutdown()
+	}()
+
 	logger := getDefaultLogger()
 	logger.Info("starting")
 	defer logger.Info("stopped")
-	if err := Main(logger); err != nil {
+	if err := Main(ctx, logger); err != nil {
 		logger.Error("exit-error", err)
 		os.Exit(1)
 	}

--- a/main_app_api_test.go
+++ b/main_app_api_test.go
@@ -109,7 +109,7 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 		Expect(err).ToNot(HaveOccurred())
 		q := u.Query()
 		q.Set("org_guid", anOrgGUIDWithEvents)
-		q.Set("range_start", "epoch")
+		q.Set("range_start", "1970-01-01")
 		q.Set("range_stop", "2030-01-01")
 		u.RawQuery = q.Encode()
 
@@ -154,7 +154,7 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 		Expect(err).ToNot(HaveOccurred())
 		q := u.Query()
 		q.Set("org_guid", anOrgGUIDWithEvents)
-		q.Set("range_start", "epoch")
+		q.Set("range_start", "1970-01-01")
 		q.Set("range_stop", "2030-01-01")
 		u.RawQuery = q.Encode()
 
@@ -205,7 +205,7 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 		Expect(err).ToNot(HaveOccurred())
 		q := u.Query()
 		q.Set("org_guid", eventstore.DummyOrgGUID)
-		q.Set("range_start", "epoch")
+		q.Set("range_start", "1970-01-01")
 		q.Set("range_stop", "2030-01-01")
 		q.Set("events", inputEventsJSON)
 		u.RawQuery = q.Encode()

--- a/main_app_api_test.go
+++ b/main_app_api_test.go
@@ -10,13 +10,8 @@ import (
 	"os/exec"
 	"time"
 
-	"context"
-	"sync"
-
-	"code.cloudfoundry.org/lager"
 	"github.com/alphagov/paas-billing/eventio"
 	"github.com/alphagov/paas-billing/eventstore"
-	"github.com/alphagov/paas-billing/fakes"
 	"github.com/alphagov/paas-billing/testenv"
 	"github.com/labstack/echo"
 	. "github.com/onsi/ginkgo"
@@ -34,6 +29,7 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 	var (
 		err                 error
 		session             *Session
+		session_collector   *Session
 		tempDB              *testenv.TempDB
 		anOrgGUIDWithEvents string
 		validAuthToken      = os.Getenv("TEST_AUTH_TOKEN")
@@ -59,32 +55,18 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 	})
 
 	By("Starting the app", func() {
-		cmd := exec.Command(CMD)
-		session, err = Start(cmd, GinkgoWriter, GinkgoWriter)
+		api := exec.Command(BinaryPath, "api")
+		collector := exec.Command(BinaryPath, "collector")
+		session, err = Start(api, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+		session_collector, err = Start(collector, GinkgoWriter, GinkgoWriter)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(session.Out, 10*time.Second).Should(Say("paas-billing.starting"))
 	})
 
 	defer By("Killing the app (if it hasn't already been shutdown)", func() {
 		session.Kill()
-	})
-
-	By("Waiting for the EventStore to report it has been initialized", func() {
-		Eventually(session.Out, 20*time.Second).Should(Say("paas-billing.store.initializing"))
-		Eventually(session.Out, 60*time.Second).Should(Say("paas-billing.store.initialized"))
-	})
-
-	By("Waiting for the HistoricDataStore to report it has been initialized", func() {
-		Eventually(session.Out, 60*time.Second).Should(Say("paas-billing.historic-data-store.initialized"))
-	})
-
-	By("Ensuring Service/ServicePlan data exists after HistoricDataStore.Init", func() {
-		Expect(
-			tempDB.Get(`select count(*) from service_plans`),
-		).To(BeNumerically(">", 0), "expected some service_plans to be collected during init")
-		Expect(
-			tempDB.Get(`select count(*) from services`),
-		).To(BeNumerically(">", 0), "expected some services to be collected during init")
+		session_collector.Kill()
 	})
 
 	By("Waiting for the EventServer to report it has started", func() {
@@ -100,7 +82,7 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 	By("Waiting for some events to be processed in the database", func() {
 		Eventually(func() interface{} {
 			return tempDB.Get(`select count(*) from events`)
-		}, 5*time.Minute).Should(BeNumerically(">", 0), "expected some events to processed")
+		}, 5*time.Second).Should(BeNumerically(">", 0), "expected some events to processed")
 		anOrgGUIDWithEvents = tempDB.Get(`select org_guid::text from events limit 1`).(string)
 		Expect(anOrgGUIDWithEvents).ToNot(BeEmpty())
 	})
@@ -256,63 +238,5 @@ var _ = It("Should perform a smoke test against a real environment", func() {
 
 	By("Waiting until the process exits cleanly", func() {
 		Eventually(session, 60*time.Second).Should(Exit(0))
-	})
-})
-
-var _ = Describe("runRefreshAndConsolidateLoop", func() {
-	var (
-		fakeStore *fakes.FakeEventStore
-		logger    lager.Logger
-	)
-
-	BeforeEach(func() {
-		fakeStore = &fakes.FakeEventStore{}
-		logger = lager.NewLogger("test")
-	})
-
-	It("should call Refresh and Consolidate every 'Schedule'", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-
-		wg := sync.WaitGroup{}
-		defer wg.Wait()
-		defer cancel()
-
-		go func() {
-			wg.Add(1)
-			runRefreshAndConsolidateLoop(ctx, logger, 1*time.Nanosecond, fakeStore)
-			wg.Done()
-		}()
-
-		Eventually(func() int {
-			return fakeStore.RefreshCallCount()
-		}).Should(BeNumerically(">=", 1))
-
-		Eventually(func() int {
-			return fakeStore.ConsolidateAllCallCount()
-		}).Should(BeNumerically(">=", 1))
-	})
-
-	It("should not call Consolidate if Refresh fails", func() {
-		fakeStore.RefreshReturns(fmt.Errorf("some-error"))
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-
-		wg := sync.WaitGroup{}
-		defer wg.Wait()
-		defer cancel()
-
-		go func() {
-			wg.Add(1)
-			runRefreshAndConsolidateLoop(ctx, logger, 1*time.Nanosecond, fakeStore)
-			wg.Done()
-		}()
-
-		Eventually(func() int {
-			return fakeStore.RefreshCallCount()
-		}).Should(BeNumerically(">=", 2))
-
-		Consistently(func() int {
-			return fakeStore.ConsolidateAllCallCount()
-		}).Should(BeNumerically("==", 0))
 	})
 })

--- a/main_app_collector_test.go
+++ b/main_app_collector_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"context"
+	"sync"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/alphagov/paas-billing/fakes"
+	"github.com/alphagov/paas-billing/testenv"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = It("Should perform a smoke test against a real environment", func() {
+	enabled := os.Getenv("ENABLE_SMOKE_TESTS")
+	if enabled != "true" {
+		Skip("smoke tests are disabled set ENABLE_SMOKE_TESTS=true to enable them")
+	}
+
+	var (
+		err                 error
+		session             *Session
+		tempDB              *testenv.TempDB
+		anOrgGUIDWithEvents string
+		validAuthToken      = os.Getenv("TEST_AUTH_TOKEN")
+		//httpClient          = &http.Client{}
+		port = "8765"
+	)
+
+	By("Setting up a environment", func() {
+		tempDB, err = testenv.New()
+		Expect(err).ToNot(HaveOccurred())
+		os.Setenv("DATABASE_URL", tempDB.TempConnectionString)
+		os.Setenv("COLLECTOR_MIN_WAIT_TIME", "100ms")
+		os.Setenv("PROCESSOR_SCHEDULE", "5s")
+		os.Setenv("PORT", port)
+	})
+
+	defer By("Removing the temp database environment", func() {
+		tempDB.Close()
+	})
+
+	By("Ensuring a TEST_AUTH_TOKEN environment variable is set", func() {
+		Expect(validAuthToken).ToNot(BeEmpty(), "TEST_AUTH_TOKEN must be set to a valid cf oauth-token for this test")
+	})
+
+	By("Starting the app", func() {
+		cmd := exec.Command(BinaryPath, "collector")
+		cmd.Env = os.Environ()
+		session, err = Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(session.Out, 10*time.Second).Should(Say("paas-billing.starting"))
+	})
+
+	defer By("Killing the app (if it hasn't already been shutdown)", func() {
+		session.Kill()
+	})
+
+	By("Waiting for the EventStore to report it has been initialized", func() {
+		Eventually(session.Out, 20*time.Second).Should(Say("paas-billing.store.initializing"))
+		Eventually(session.Out, 60*time.Second).Should(Say("paas-billing.store.initialized"))
+	})
+
+	By("Waiting for the HistoricDataStore to report it has been initialized", func() {
+		Eventually(session.Out, 60*time.Second).Should(Say("paas-billing.historic-data-store.initialized"))
+	})
+
+	By("Ensuring Service/ServicePlan data exists after HistoricDataStore.Init", func() {
+		Expect(
+			tempDB.Get(`select count(*) from service_plans`),
+		).To(BeNumerically(">", 0), "expected some service_plans to be collected during init")
+		Expect(
+			tempDB.Get(`select count(*) from services`),
+		).To(BeNumerically(">", 0), "expected some services to be collected during init")
+	})
+
+	By("Waiting for some raw events to be collected in the database", func() {
+		Eventually(func() interface{} {
+			return tempDB.Get(`select count(*) from app_usage_events`)
+		}, 1*time.Minute).Should(BeNumerically(">", 0), "expected some app_usage_events to be collected")
+	})
+
+	By("Waiting for some events to be processed in the database", func() {
+		Eventually(func() interface{} {
+			return tempDB.Get(`select count(*) from events`)
+		}, 5*time.Minute).Should(BeNumerically(">", 0), "expected some events to processed")
+		anOrgGUIDWithEvents = tempDB.Get(`select org_guid::text from events limit 1`).(string)
+		Expect(anOrgGUIDWithEvents).ToNot(BeEmpty())
+	})
+
+	By("Sending SIGTERM to the process", func() {
+		session.Terminate()
+		Eventually(session.Out, 10*time.Second).Should(Say("paas-billing.stopping"))
+	})
+
+	By("Waiting until the process exits cleanly", func() {
+		Eventually(session, 60*time.Second).Should(Exit(0))
+	})
+})
+
+var _ = Describe("runRefreshAndConsolidateLoop", func() {
+	var (
+		fakeStore *fakes.FakeEventStore
+		logger    lager.Logger
+	)
+
+	BeforeEach(func() {
+		fakeStore = &fakes.FakeEventStore{}
+		logger = lager.NewLogger("test")
+	})
+
+	It("should call Refresh and Consolidate every 'Schedule'", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+		wg := sync.WaitGroup{}
+		defer wg.Wait()
+		defer cancel()
+
+		go func() {
+			wg.Add(1)
+			runRefreshAndConsolidateLoop(ctx, logger, 1*time.Nanosecond, fakeStore)
+			wg.Done()
+		}()
+
+		Eventually(func() int {
+			return fakeStore.RefreshCallCount()
+		}).Should(BeNumerically(">=", 1))
+
+		Eventually(func() int {
+			return fakeStore.ConsolidateAllCallCount()
+		}).Should(BeNumerically(">=", 1))
+	})
+
+	It("should not call Consolidate if Refresh fails", func() {
+		fakeStore.RefreshReturns(fmt.Errorf("some-error"))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+		wg := sync.WaitGroup{}
+		defer wg.Wait()
+		defer cancel()
+
+		go func() {
+			wg.Add(1)
+			runRefreshAndConsolidateLoop(ctx, logger, 1*time.Nanosecond, fakeStore)
+			wg.Done()
+		}()
+
+		Eventually(func() int {
+			return fakeStore.RefreshCallCount()
+		}).Should(BeNumerically(">=", 2))
+
+		Consistently(func() int {
+			return fakeStore.ConsolidateAllCallCount()
+		}).Should(BeNumerically("==", 0))
+	})
+})

--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 )
 
-var CMD string
+var BinaryPath string
 
 var _ = BeforeSuite(func() {
 	var err error
-	CMD, err = gexec.Build("github.com/alphagov/paas-billing")
+	BinaryPath, err = gexec.Build("github.com/alphagov/paas-billing")
 	Expect(err).ToNot(HaveOccurred())
 })
 

--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -4,8 +4,7 @@ applications:
    memory: 128M
    disk_quota: 100M
    instances: 2
-   buildpacks:
-   - go_buildpack
+   buildpack: go_buildpack
    health-check-type: http
    env:
      GOPACKAGENAME: github.com/alphagov/paas-billing

--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -1,0 +1,12 @@
+---
+applications:
+ - name: paas-billing-api
+   memory: 128M
+   disk_quota: 100M
+   instances: 2
+   buildpacks:
+   - go_buildpack
+   health-check-type: http
+   env:
+     GOPACKAGENAME: github.com/alphagov/paas-billing
+   command: ./bin/paas-billing api

--- a/manifest-collector.yml
+++ b/manifest-collector.yml
@@ -1,11 +1,13 @@
 ---
 applications:
- - name: paas-billing
+ - name: paas-billing-collector
    memory: 128M
    disk_quota: 100M
    instances: 1
-   buildpack: go_buildpack
+   buildpacks:
+   - go_buildpack
    health-check-type: process
+   no-route: true
    env:
      GOPACKAGENAME: github.com/alphagov/paas-billing
-   command: ./bin/paas-billing
+   command: ./bin/paas-billing collector

--- a/manifest-collector.yml
+++ b/manifest-collector.yml
@@ -4,8 +4,7 @@ applications:
    memory: 128M
    disk_quota: 100M
    instances: 1
-   buildpacks:
-   - go_buildpack
+   buildpack: go_buildpack
    health-check-type: process
    no-route: true
    env:


### PR DESCRIPTION
What
----

This PR splits the API server and event collector into 2 separately-runnable components, in the same `paas-billing` binary.

We're doing this because we need to make the API server blue-green-deployable. This means that it needs to be possible to run it twice, simultaneously, against the same CF.

This is a problem within the current architecture as the collector and the API both run in the same process and we can't allow the collector to run more than once as we're unsure if this might have an effect on the bills produced.

The net result of this is that we need to split this application into 2, the API and the collector, so that we can blue-green-deploy the API portion whilst leaving the deployment of the collector as a simple `cf push` (which results in no more than one instance running).

We achieve this here by adding a second-level noun to the program's invocation and starting only those sections of the program as are required.

To use this: where previously you ran `./path/to/paas-billing`, now to start the collector you should run `./path/to/paas-billing collector` and to start the api/event server you should run `./path/to/paas-billing api`.

We haven't implemented the ability to run both components at once.

How to review
-----

- Code review.

- Smoke-tests: as we began this story, the smoke tests weren't passing on master as they've bitrotted due to not being run anywhere automatically. We've fixed a few bits up, but we ran out of time to get them back to a known-good state. Therefore, unless the reviewer wants to burn some time on getting `master` smoke tests passing, then seeing if this branch makes things worse, we suggest not running them. Possibly `pending-discuss` a story to knock them into shape and into a pipeline somewhere.

- Dev env: we have tested there are no obvious (double-counting; zero-counting) issues in the `jonmtest` env by:
  - starting a large app
  - waiting for over 30 minutes
  - stopping the app
  - waiting for the next 30m cadence of bill generation/update to ocurr
  - observing that the right charge for this app is visible on the current month's bill on paasmin.

Who can review
-----

Anyone except @bandesz and @jpluscplusm 