### PR TITLE
[#162479783] Ignore STAGING_START events without a STAGING_STOP

### DIFF
--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -216,7 +216,12 @@ INSERT INTO events with
 	event_ranges as (
 		select
 			*,
-			tstzrange(created_at, lead(created_at, 1, now()) over resource_states) as duration
+			tstzrange(created_at,
+				lead(created_at, 1,
+					case when event_type = 'staging' then created_at
+					else now() end
+				) over resource_states
+			) as duration
 		from
 			raw_events_with_injected_values
 		window


### PR DESCRIPTION
What
----

We have found several cases in our production billing API where
there are STAGING_START events registered without a corresponding
associated STAGING_STOP.

This causes our billing platform to consider that the staging
phase did not ever finish, and we are billing the tenants forever.

Instead, if there is a STAGING_START but not a STAGING_STOP, we want
that to be ignored from the computation of events:

 - If the application is being staged in that very moment, the events
   would be taken into account later anyway. We do not consolidate
   the billing until it passed several days, as in commit
   0a93fcc1920a1dab6ca5dacfc31b05e4b17be197.

 - We can assume the cost of some minutes of staging
   if we failed recording it.

To discard these events, we set a empty duration when computing the
event_ranges, by conditionally changing the default value of
the function `lead(...) over`[1]. If there is not value after this
event and the `event_type` is `staging`, the duration will be empty
`created_at-created_at`. Otherwise, we use now().

Any event with empty duration is discarded later.

Q: Why do we record STAGING_START without STAGING_STOP?

I am not sure about the circunstances of this, but I suspect that
is caused due failed staging tasks that fail in the cloudcontroller
and are not registered as stopped. This can happen, for instance,
if a worker is stopped or fails recording the staging step.
In the cloud controller the start and stop events happen in
different transactions, and in the CC a failed staging task
might be simply discarded and not cleared up.

This problem does not appear with apps because a running app will
be recorded as "running" or "stopped" or "deleted" in the database,
and the corresponding event registered in a transaction.

NOTE: would this happen with TASKS?

[1] https://www.postgresql.org/docs/8.4/functions-window.html

How to review
-----

Code review

Who can review
-----

Not me