### PR TITLE
[SUPPORT] Increase the eventstore's init and refresh timeouts to 15 minutes

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -24,8 +24,8 @@ const (
 	ComputeServiceGUID    = "4f6f0a18-cdd4-4e51-8b6b-dc39b696e61b"
 	TaskPlanGUID          = "ebfa9453-ef66-450c-8c37-d53dfd931038"
 	StagingPlanGUID       = "9d071c77-7a68-4346-9981-e8dafac95b6f"
-	DefaultInitTimeout    = 5 * time.Minute
-	DefaultRefreshTimeout = 5 * time.Minute
+	DefaultInitTimeout    = 15 * time.Minute
+	DefaultRefreshTimeout = 15 * time.Minute
 	DefaultStoreTimeout   = 45 * time.Second
 	DefaultQueryTimeout   = 45 * time.Second
 )


### PR DESCRIPTION
What
----

On prod it takes more than 5 minutes to initialise the database. The init
therefore timeouts and the application exits.

As a quickfix we'll increase the timeouts.

How to review
-----

Code review.

Who can review
-----

Not me.
