### PR TITLE
[#163651298] Update process that re-creates the events table

### DIFF
--- a/eventstore/sql/create_app_usage_events.sql
+++ b/eventstore/sql/create_app_usage_events.sql
@@ -1,20 +1,13 @@
-
 CREATE TABLE IF NOT EXISTS app_usage_events (
 	id SERIAL, -- this should probably be called "sequence" it's not really an id
-	guid CHAR(36) UNIQUE,
-	created_at TIMESTAMP,
-	raw_message JSONB
+	guid uuid UNIQUE NOT NULL,
+	created_at timestamptz NOT NULL,
+	raw_message JSONB NOT NULL
 );
 
-ALTER TABLE app_usage_events ALTER COLUMN guid SET NOT NULL;
-ALTER TABLE app_usage_events ALTER COLUMN created_at SET NOT NULL;
-ALTER TABLE app_usage_events ALTER COLUMN raw_message SET NOT NULL;
 CREATE INDEX IF NOT EXISTS app_usage_id_idx ON app_usage_events (id);
 CREATE INDEX IF NOT EXISTS app_usage_state_idx ON app_usage_events ( (raw_message->>'state') );
 CREATE INDEX IF NOT EXISTS app_usage_space_name_idx ON app_usage_events ( (raw_message->>'space_name') text_pattern_ops);
-
-ALTER TABLE app_usage_events ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC';
-ALTER TABLE app_usage_events ALTER COLUMN guid TYPE uuid USING guid::uuid;
 
 DO $$ BEGIN
 	ALTER TABLE app_usage_events ADD CONSTRAINT created_at_not_zero_value CHECK (created_at > 'epoch'::timestamptz);

--- a/eventstore/sql/create_base_objects.sql
+++ b/eventstore/sql/create_base_objects.sql
@@ -1,3 +1,8 @@
+DROP TABLE IF EXISTS pricing_plan_components;
+DROP TABLE IF EXISTS pricing_plans;
+DROP TABLE IF EXISTS vat_rates;
+DROP TABLE IF EXISTS currency_rates;
+
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE OR REPLACE FUNCTION to_seconds(tstzrange) RETURNS numeric AS $$

--- a/eventstore/sql/create_custom_types.sql
+++ b/eventstore/sql/create_custom_types.sql
@@ -1,0 +1,18 @@
+DO $$ BEGIN
+CREATE TYPE vat_code AS ENUM ('Standard', 'Reduced', 'Zero');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+CREATE TYPE currency_code AS ENUM ('USD', 'GBP', 'EUR');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+CREATE TYPE resource_state AS ENUM ('STARTED', 'STOPPED');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+

--- a/eventstore/sql/create_ephemeral_objects.sql
+++ b/eventstore/sql/create_ephemeral_objects.sql
@@ -123,9 +123,6 @@ END; $$ LANGUAGE plpgsql IMMUTABLE;
 
 -------------------------------------- SCHEMA
 
-CREATE TYPE vat_code AS ENUM ('Standard', 'Reduced', 'Zero');
-CREATE TYPE currency_code AS ENUM ('USD', 'GBP', 'EUR');
-
 CREATE TABLE pricing_plans (
 	plan_guid uuid NOT NULL,
 	valid_from timestamptz NOT NULL,
@@ -189,7 +186,3 @@ CREATE TABLE pricing_plan_components (
 	CONSTRAINT formula_must_not_be_blank CHECK (length(trim(formula)) > 0)
 );
 CREATE TRIGGER tgr_ppc_validate_formula BEFORE INSERT OR UPDATE ON pricing_plan_components FOR EACH ROW EXECUTE PROCEDURE validate_formula();
-
-
-CREATE TYPE resource_state AS ENUM ('STARTED', 'STOPPED');
-

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -1,4 +1,4 @@
-CREATE TABLE events (
+CREATE TABLE events_temp (
 	event_guid uuid PRIMARY KEY NOT NULL,
 	resource_guid uuid NOT NULL,
 	resource_name text NOT NULL,
@@ -22,7 +22,7 @@ CREATE TABLE events (
 -- extract useful stuff from usage events
 -- we treat both apps and services as "resources" so normalize the fields
 -- we normalize states to just STARTED/STOPPED because we treat consecutive STARTED to mean "update"
-INSERT INTO events with
+INSERT INTO events_temp with
 	raw_events as (
 		(
 			select
@@ -310,8 +310,17 @@ INSERT INTO events with
 		event_sequence, event_guid
 ;
 
-CREATE INDEX events_org_idx ON events (org_guid);
-CREATE INDEX events_space_idx ON events (space_guid);
-CREATE INDEX events_resource_idx ON events (resource_guid);
-CREATE INDEX events_duration_idx ON events using gist (duration);
-CREATE INDEX events_plan_idx ON events (plan_guid);
+CREATE INDEX events_org_temp_idx ON events_temp (org_guid);
+CREATE INDEX events_space_temp_idx ON events_temp (space_guid);
+CREATE INDEX events_resource_temp_idx ON events_temp (resource_guid);
+CREATE INDEX events_duration_temp_idx ON events_temp using gist (duration);
+CREATE INDEX events_plan_temp_idx ON events_temp (plan_guid);
+
+DROP TABLE IF EXISTS events;
+ALTER TABLE events_temp RENAME TO events;
+ALTER INDEX events_temp_pkey RENAME TO events_pkey;
+ALTER INDEX events_org_temp_idx RENAME TO events_org_idx;
+ALTER INDEX events_space_temp_idx RENAME TO events_space_idx;
+ALTER INDEX events_resource_temp_idx RENAME TO events_resource_idx;
+ALTER INDEX events_duration_temp_idx RENAME TO events_duration_idx;
+ALTER INDEX events_plan_temp_idx RENAME TO events_plan_idx;

--- a/eventstore/sql/create_service_usage_events.sql
+++ b/eventstore/sql/create_service_usage_events.sql
@@ -1,19 +1,11 @@
-
 CREATE TABLE IF NOT EXISTS service_usage_events (
 	id SERIAL,
-	guid CHAR(36) UNIQUE,
-	created_at TIMESTAMP,
-	raw_message JSONB
+	guid uuid UNIQUE NOT NULL,
+	created_at timestamptz NOT NULL,
+	raw_message JSONB NOT NULL
 );
 
-ALTER TABLE service_usage_events ALTER COLUMN guid SET NOT NULL;
-ALTER TABLE service_usage_events ALTER COLUMN created_at SET NOT NULL;
-ALTER TABLE service_usage_events ALTER COLUMN raw_message SET NOT NULL;
 CREATE INDEX IF NOT EXISTS service_usage_id_idx ON service_usage_events (id);
 CREATE INDEX IF NOT EXISTS service_usage_state_idx ON service_usage_events ( (raw_message->>'state') );
 CREATE INDEX IF NOT EXISTS service_usage_type_idx ON service_usage_events ( (raw_message->>'service_instance_type') );
 CREATE INDEX IF NOT EXISTS service_usage_space_name_idx ON service_usage_events ( (raw_message->>'space_name') text_pattern_ops);
-
-ALTER TABLE service_usage_events ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC';
-ALTER TABLE service_usage_events ALTER COLUMN guid TYPE uuid USING guid::uuid;
-

--- a/eventstore/sql/drop_ephemeral_objects.sql
+++ b/eventstore/sql/drop_ephemeral_objects.sql
@@ -1,5 +1,3 @@
-DROP MATERIALIZED VIEW IF EXISTS billable;           -- FIXME legacy: remove me later
-DROP MATERIALIZED VIEW IF EXISTS resource_durations;           -- FIXME legacy: remove me later
 DROP TABLE IF EXISTS pricing_plan_components;
 DROP TABLE IF EXISTS pricing_plans;
 DROP TABLE IF EXISTS vat_rates;

--- a/eventstore/sql/drop_ephemeral_objects.sql
+++ b/eventstore/sql/drop_ephemeral_objects.sql
@@ -7,6 +7,3 @@ DROP TABLE IF EXISTS pricing_plan_components;
 DROP TABLE IF EXISTS pricing_plans;
 DROP TABLE IF EXISTS vat_rates;
 DROP TABLE IF EXISTS currency_rates;
-DROP TYPE IF EXISTS resource_state;
-DROP TYPE IF EXISTS currency_code;
-DROP TYPE IF EXISTS vat_code;

--- a/eventstore/sql/drop_ephemeral_objects.sql
+++ b/eventstore/sql/drop_ephemeral_objects.sql
@@ -1,4 +1,0 @@
-DROP TABLE IF EXISTS pricing_plan_components;
-DROP TABLE IF EXISTS pricing_plans;
-DROP TABLE IF EXISTS vat_rates;
-DROP TABLE IF EXISTS currency_rates;

--- a/eventstore/sql/drop_ephemeral_objects.sql
+++ b/eventstore/sql/drop_ephemeral_objects.sql
@@ -1,8 +1,5 @@
 DROP MATERIALIZED VIEW IF EXISTS billable;           -- FIXME legacy: remove me later
 DROP MATERIALIZED VIEW IF EXISTS resource_durations;           -- FIXME legacy: remove me later
-DROP FUNCTION IF EXISTS generate_billable_event_components();
-DROP TABLE IF EXISTS billable_event_components;
-DROP TABLE IF EXISTS events;
 DROP TABLE IF EXISTS pricing_plan_components;
 DROP TABLE IF EXISTS pricing_plans;
 DROP TABLE IF EXISTS vat_rates;

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -61,11 +61,15 @@ func (s *EventStore) Init() error {
 	s.logger.Info("initializing")
 	ctx, cancel := context.WithTimeout(s.ctx, DefaultInitTimeout)
 	defer cancel()
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
+
 	sqlFiles := []string{
+		"create_custom_types.sql",
 		"create_services.sql",
 		"create_service_plans.sql",
 		"drop_ephemeral_objects.sql",
@@ -77,7 +81,7 @@ func (s *EventStore) Init() error {
 			return err
 		}
 	}
-	defer tx.Rollback()
+
 	sqlFiles = []string{
 		"create_app_usage_events.sql",
 		"create_service_usage_events.sql",

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -72,7 +72,7 @@ func (s *EventStore) Init() error {
 		"create_custom_types.sql",
 		"create_services.sql",
 		"create_service_plans.sql",
-		"drop_ephemeral_objects.sql",
+		"create_base_objects.sql",
 	}
 	for _, sqlFile := range sqlFiles {
 		err := s.execFile(tx, sqlFile)

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -73,34 +73,40 @@ func (s *EventStore) Init() error {
 		"create_services.sql",
 		"create_service_plans.sql",
 		"create_base_objects.sql",
+		"create_orgs.sql",
+		"create_spaces.sql",
 	}
 	for _, sqlFile := range sqlFiles {
-		err := s.execFile(tx, sqlFile)
+		err := s.runSQLFile(tx, sqlFile)
 		if err != nil {
-			s.logger.Error(fmt.Sprintf("init-failed:%s", sqlFile), err)
+			s.logger.Error("init", err)
 			return err
 		}
 	}
+	if err := s.initVATRates(tx); err != nil {
+		return fmt.Errorf("failed to init VAT rates: %s", err)
+	}
+	if err := s.initCurrencyRates(tx); err != nil {
+		return fmt.Errorf("failed to init currency rates: %s", err)
+	}
+	if err := s.initPlans(tx); err != nil {
+		return fmt.Errorf("failed to init plans: %s", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
 
-	sqlFiles = []string{
+	if err := s.runSQLFilesInTransaction(
+		ctx,
 		"create_app_usage_events.sql",
 		"create_service_usage_events.sql",
 		"create_compose_audit_events.sql",
-		"create_orgs.sql",
-		"create_spaces.sql",
 		"create_consolidated_billable_events.sql",
-	}
-	for _, sqlFile := range sqlFiles {
-		err := s.execFile(tx, sqlFile)
-		if err != nil {
-			s.logger.Error(fmt.Sprintf("init-failed:%s", sqlFile), err)
-			return err
-		}
-	}
-	if err := s.refresh(tx); err != nil {
+	); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+
+	if err := s.regenerateEvents(); err != nil {
 		return err
 	}
 	s.logger.Info("initialized")
@@ -110,52 +116,47 @@ func (s *EventStore) Init() error {
 // Refresh triggers regeneration of the cached normalized view of the event dat and rebuilds the
 // billable components. Ideally you should do this once a day
 func (s *EventStore) Refresh() error {
+	return s.regenerateEvents()
+}
+
+func (s *EventStore) regenerateEvents() error {
 	ctx, cancel := context.WithTimeout(s.ctx, DefaultRefreshTimeout)
 	defer cancel()
+
+	if err := s.runSQLFilesInTransaction(
+		ctx,
+		"create_events.sql",
+	); err != nil {
+		return err
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
-	if err := s.refresh(tx); err != nil {
-		return err
-	}
-	return tx.Commit()
-}
 
-// refresh rebuilds the schema in the given transaction
-func (s *EventStore) refresh(tx *sql.Tx) error {
-	startTime := time.Now()
-	s.logger.Info("started-processing-events")
-	// drop all the projection data
-	if err := s.execFile(tx, "drop_ephemeral_objects.sql"); err != nil {
+	if s.cfg.IgnoreMissingPlans {
+		if err := s.generateMissingPlans(tx); err != nil {
+			return err
+		}
+	}
+
+	if err := checkPlanConsistency(tx); err != nil {
 		return err
 	}
-	// create the ephemeral configuration objects (pricing/plans/etc)
-	if err := s.execFile(tx, "create_ephemeral_objects.sql"); err != nil {
+
+	if err := tx.Commit(); err != nil {
 		return err
 	}
-	// reset the event normalization
-	if err := s.execFile(tx, "create_events.sql"); err != nil {
+
+	if err := s.runSQLFilesInTransaction(
+		ctx,
+		"create_billable_event_components.sql",
+	); err != nil {
 		return err
 	}
-	// populate the config
-	if err := s.initVATRates(tx); err != nil {
-		return err
-	}
-	if err := s.initCurrencyRates(tx); err != nil {
-		return err
-	}
-	if err := s.initPlans(tx); err != nil {
-		return err
-	}
-	// create the billable components view of the data
-	if err := s.execFile(tx, "create_billable_event_components.sql"); err != nil {
-		return err
-	}
-	s.logger.Info("finished-processing-events", lager.Data{
-		"elapsed": time.Since(startTime),
-	})
+
 	return nil
 }
 
@@ -243,17 +244,7 @@ func (s *EventStore) initPlans(tx *sql.Tx) (err error) {
 		}
 	}
 
-	if s.cfg.IgnoreMissingPlans {
-		if err := s.generateMissingPlans(tx); err != nil {
-			return err
-		}
-	}
-
 	if err := checkPricingComponents(tx); err != nil {
-		return err
-	}
-
-	if err := checkPlanConsistency(tx); err != nil {
 		return err
 	}
 
@@ -667,20 +658,42 @@ func checkPlanConsistency(tx *sql.Tx) error {
 	return nil
 }
 
-// execFile executes an sql file in the given transaction
-func (s *EventStore) execFile(tx *sql.Tx, filename string) error {
+func (s *EventStore) runSQLFilesInTransaction(ctx context.Context, filenames ...string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, filename := range filenames {
+		if err := s.runSQLFile(tx, filename); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *EventStore) runSQLFile(tx *sql.Tx, filename string) error {
+	startTime := time.Now()
+	s.logger.Info("run-sql-file", map[string]interface{}{"sqlFile": filename})
+
+	defer func() {
+		s.logger.Info("finish-sql-file", lager.Data{
+			"sqlFile": filename,
+			"elapsed": time.Since(startTime),
+		})
+	}()
+
 	schemaFilename := schemaFile(filename)
 	sql, err := ioutil.ReadFile(schemaFilename)
 	if err != nil {
 		return fmt.Errorf("failed to execute sql file %s: %s", schemaFilename, err)
 	}
-	s.logger.Info("executing-sql", lager.Data{
-		"filename": filename,
-	})
+
 	_, err = tx.Exec(string(sql))
 	if err != nil {
 		return wrapPqError(err, schemaFilename)
 	}
+
 	return nil
 }
 

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -127,46 +127,32 @@ func (s *EventStore) Refresh() error {
 func (s *EventStore) refresh(tx *sql.Tx) error {
 	startTime := time.Now()
 	s.logger.Info("started-processing-events")
-	s.logger.Info("started-drop_ephemeral_objects")
 	// drop all the projection data
 	if err := s.execFile(tx, "drop_ephemeral_objects.sql"); err != nil {
 		return err
 	}
-	s.logger.Info("finished-drop_ephemeral_objects")
-	s.logger.Info("started-create_ephemeral_objects")
 	// create the ephemeral configuration objects (pricing/plans/etc)
 	if err := s.execFile(tx, "create_ephemeral_objects.sql"); err != nil {
 		return err
 	}
-	s.logger.Info("finished-create_ephemeral_objects")
-	s.logger.Info("started-create_events")
 	// reset the event normalization
 	if err := s.execFile(tx, "create_events.sql"); err != nil {
 		return err
 	}
-	s.logger.Info("finished-create_events")
-	s.logger.Info("started-initVATRates")
 	// populate the config
 	if err := s.initVATRates(tx); err != nil {
 		return err
 	}
-	s.logger.Info("finished-initVATRates")
-	s.logger.Info("started-initCurrencyRates")
 	if err := s.initCurrencyRates(tx); err != nil {
 		return err
 	}
-	s.logger.Info("finished-initCurrencyRates")
-	s.logger.Info("started-initPlans")
 	if err := s.initPlans(tx); err != nil {
 		return err
 	}
-	s.logger.Info("finished-initPlans")
-	s.logger.Info("started-create_billable_event_components")
 	// create the billable components view of the data
 	if err := s.execFile(tx, "create_billable_event_components.sql"); err != nil {
 		return err
 	}
-	s.logger.Info("finished-create_billable_event_components")
 	s.logger.Info("finished-processing-events", lager.Data{
 		"elapsed": time.Since(startTime),
 	})


### PR DESCRIPTION
What
----

The events table is currently dropped and re-created every 30mins. During this process, the billing page and pricing calculator queries are blocked for several minutes. 

This PR updates the process to create temporary tables that are renamed and run in separate transactions so the queries are unblocked. Also includes a clean up of the SQL files.

How to review
-----

- Code Review
- Deploy to a dev env using this [paas-cf branch](https://github.com/alphagov/paas-cf/pull/1758)

Who can review
-----

Not @mogds @bandesz 
