### PR TITLE
Disable `quota_definition_guid` field

### DIFF
--- a/eventstore/store_billable_events.go
+++ b/eventstore/store_billable_events.go
@@ -164,7 +164,6 @@ func WithBillableEvents(query string, filter eventio.EventFilter, args ...interf
 				b.resource_type,
 				b.org_guid,
 				b.org_name,
-				o.quota_definition_guid,
 				b.space_guid,
 				b.space_name,
 				b.plan_guid,
@@ -189,8 +188,6 @@ func WithBillableEvents(query string, filter eventio.EventFilter, args ...interf
 			from
 			    filtered_range,
 				billable_event_components b
-			left join
-				orgs o on b.org_guid = o.guid
 			where
 				duration && filtered_range
 				%s
@@ -207,7 +204,7 @@ func WithBillableEvents(query string, filter eventio.EventFilter, args ...interf
 				resource_type,
 				org_guid,
 				org_name,
-				quota_definition_guid,
+				null::uuid as quota_definition_guid,
 				space_guid,
 				space_name,
 				plan_guid,


### PR DESCRIPTION
What
----

https://github.com/alphagov/paas-billing/pull/64's `LEFT JOIN` on `orgs` did not consider that some organisations have multiple rows in `orgs`. This led to the join multiplying the number of rows, which would have led to inflated bills if not noticed.

This commit sets `quota_definition_guid` to be empty and removes the `LEFT JOIN` until we can do better. It seems likely that a separate API to retrieve org quotas over time is a better solution to the user need, but that will require work to `paas-admin` that we don't have time for right now.

How to review
-----

Code review.

Who can review
-----

Not @46bit 