### PR TITLE
Increase Default Init and Refresh timeouts

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -24,8 +24,8 @@ const (
 	ComputeServiceGUID    = "4f6f0a18-cdd4-4e51-8b6b-dc39b696e61b"
 	TaskPlanGUID          = "ebfa9453-ef66-450c-8c37-d53dfd931038"
 	StagingPlanGUID       = "9d071c77-7a68-4346-9981-e8dafac95b6f"
-	DefaultInitTimeout    = 15 * time.Minute
-	DefaultRefreshTimeout = 15 * time.Minute
+	DefaultInitTimeout    = 25 * time.Minute
+	DefaultRefreshTimeout = 25 * time.Minute
 	DefaultStoreTimeout   = 45 * time.Second
 	DefaultQueryTimeout   = 45 * time.Second
 )


### PR DESCRIPTION
What
----

It looks like the `create-events.sql` script has been timing out in the
London paas-billing collector. Maybe if we make the timeout longer it
will stop timing out.

Choosing 25 mins instead of 30 because I think the refresh happens every
30 mins.

How to review
-----

* Code review
* Have a think about whether extending the timeouts will cause unforseen
  problems

Who can review
-----

Not me