### PR TITLE
[#165537092] Include deployment name in log lines

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,9 @@ func main() {
 	}()
 
 	logger := getDefaultLogger()
+	if deployment := os.Getenv("DEPLOY_ENV"); deployment != "" {
+		logger = logger.WithData(lager.Data{"deployment": deployment})
+	}
 	logger.Info("starting")
 	defer logger.Info("stopped")
 	if err := Main(ctx, logger); err != nil {


### PR DESCRIPTION
What
----

Adds a `deployment` field to log lines from `paas-billing`. This is needed to be able to distinguish different `paas-billing` instances using the same logging stack.

How to review
-----

* See if the tests go green;
* Code review.

Who can review
-----

Not @46bit