### PR TITLE
[#165537092] Log time elapsed by various database and processing operations

### DIFF
--- a/eventcollector/collector.go
+++ b/eventcollector/collector.go
@@ -63,10 +63,11 @@ func (c *EventCollector) Run(ctx context.Context) error {
 				continue
 			}
 			c.eventsCollected += len(collectedEvents)
+			elapsed := time.Since(startTime)
 			c.logger.Info("collected", lager.Data{
 				"count":   len(collectedEvents),
 				"kind":    c.fetcher.Kind(),
-				"elapsed": time.Since(startTime).String(),
+				"elapsed": int64(elapsed),
 			})
 		case <-ctx.Done():
 			return nil

--- a/eventcollector/collector.go
+++ b/eventcollector/collector.go
@@ -62,12 +62,11 @@ func (c *EventCollector) Run(ctx context.Context) error {
 				c.logger.Error("collect-error", err)
 				continue
 			}
-			elapsedTime := time.Since(startTime)
 			c.eventsCollected += len(collectedEvents)
 			c.logger.Info("collected", lager.Data{
-				"count":    len(collectedEvents),
-				"kind":     c.fetcher.Kind(),
-				"duration": elapsedTime.String(),
+				"count":   len(collectedEvents),
+				"kind":    c.fetcher.Kind(),
+				"elapsed": time.Since(startTime).String(),
 			})
 		case <-ctx.Done():
 			return nil

--- a/eventfetchers/cffetcher/cf_fetcher.go
+++ b/eventfetchers/cffetcher/cf_fetcher.go
@@ -77,10 +77,11 @@ func (e *CFEventFetcher) FetchEvents(ctx context.Context, lastEvent *eventio.Raw
 			})
 		}
 	}
+	elapsed := time.Since(startTime)
 	e.logger.Info("fetched", lager.Data{
 		"last_guid":   guid,
 		"event_count": len(events),
-		"elapsed":     time.Since(startTime).String(),
+		"elapsed":     int64(elapsed),
 	})
 
 	return events, nil

--- a/eventfetchers/cffetcher/cf_fetcher.go
+++ b/eventfetchers/cffetcher/cf_fetcher.go
@@ -61,6 +61,7 @@ func (e *CFEventFetcher) FetchEvents(ctx context.Context, lastEvent *eventio.Raw
 		"after_guid": guid,
 		"limit":      fetchLimit,
 	})
+	startTime := time.Now()
 	usageEvents, err := e.client.Get(guid, fetchLimit, recordMinAge)
 	if err != nil {
 		return nil, err
@@ -79,6 +80,7 @@ func (e *CFEventFetcher) FetchEvents(ctx context.Context, lastEvent *eventio.Raw
 	e.logger.Info("fetched", lager.Data{
 		"last_guid":   guid,
 		"event_count": len(events),
+		"elapsed":     time.Since(startTime).String(),
 	})
 
 	return events, nil

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -676,25 +676,31 @@ func (s *EventStore) runSQLFile(tx *sql.Tx, filename string) error {
 	startTime := time.Now()
 	s.logger.Info("run-sql-file", map[string]interface{}{"sqlFile": filename})
 
-	defer func() {
-		elapsed := time.Since(startTime)
-		s.logger.Info("finish-sql-file", lager.Data{
-			"sqlFile": filename,
-			"elapsed": int64(elapsed),
-		})
-	}()
-
 	schemaFilename := schemaFile(filename)
 	sql, err := ioutil.ReadFile(schemaFilename)
 	if err != nil {
-		return fmt.Errorf("failed to execute sql file %s: %s", schemaFilename, err)
+		err = fmt.Errorf("failed to execute sql file %s: %s", schemaFilename, err)
+		s.logger.Error("finish-sql-file", err, lager.Data{
+			"sqlFile": filename,
+			"elapsed": int64(time.Since(startTime)),
+		})
+		return err
 	}
 
 	_, err = tx.Exec(string(sql))
 	if err != nil {
-		return wrapPqError(err, schemaFilename)
+		err = wrapPqError(err, schemaFilename)
+		s.logger.Error("finish-sql-file", err, lager.Data{
+			"sqlFile": filename,
+			"elapsed": int64(time.Since(startTime)),
+		})
+		return err
 	}
 
+	s.logger.Info("finish-sql-file", lager.Data{
+		"sqlFile": filename,
+		"elapsed": int64(time.Since(startTime)),
+	})
 	return nil
 }
 

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -677,9 +677,10 @@ func (s *EventStore) runSQLFile(tx *sql.Tx, filename string) error {
 	s.logger.Info("run-sql-file", map[string]interface{}{"sqlFile": filename})
 
 	defer func() {
+		elapsed := time.Since(startTime)
 		s.logger.Info("finish-sql-file", lager.Data{
 			"sqlFile": filename,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 	}()
 

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -679,7 +679,7 @@ func (s *EventStore) runSQLFile(tx *sql.Tx, filename string) error {
 	defer func() {
 		s.logger.Info("finish-sql-file", lager.Data{
 			"sqlFile": filename,
-			"elapsed": time.Since(startTime),
+			"elapsed": time.Since(startTime).String(),
 		})
 	}()
 

--- a/eventstore/store_billable_events.go
+++ b/eventstore/store_billable_events.go
@@ -46,16 +46,17 @@ func (s *EventStore) getBillableEventRows(tx *sql.Tx, filter eventio.EventFilter
 
 	startTime := time.Now()
 	rows, err := queryJSON(tx, query, args...)
+	elapsed := time.Since(startTime)
 	if err != nil {
 		s.logger.Error("get-billable-event-rows-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return nil, err
 	}
 	s.logger.Info("get-billable-event-rows-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 
 	return &BillableEventRows{rows}, nil

--- a/eventstore/store_billable_events.go
+++ b/eventstore/store_billable_events.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/alphagov/paas-billing/eventio"
 )
 
@@ -42,10 +44,19 @@ func (s *EventStore) getBillableEventRows(tx *sql.Tx, filter eventio.EventFilter
 		return nil, err
 	}
 
+	startTime := time.Now()
 	rows, err := queryJSON(tx, query, args...)
 	if err != nil {
+		s.logger.Error("get-billable-event-rows-query", err, lager.Data{
+			"filter":  filter,
+			"elapsed": time.Since(startTime).String(),
+		})
 		return nil, err
 	}
+	s.logger.Info("get-billable-event-rows-query", lager.Data{
+		"filter":  filter,
+		"elapsed": time.Since(startTime).String(),
+	})
 
 	return &BillableEventRows{rows}, nil
 }

--- a/eventstore/store_consolidated_billable_events.go
+++ b/eventstore/store_consolidated_billable_events.go
@@ -57,6 +57,8 @@ func (e *EventStore) getConsolidatedBillableEventRows(tx *sql.Tx, filter eventio
 	if len(filterConditions) > 0 {
 		filterQuery = " and " + strings.Join(filterConditions, " and ")
 	}
+
+	startTime := time.Now()
 	rows, err := queryJSON(tx, fmt.Sprintf(`
 		select
 			event_guid,
@@ -83,8 +85,16 @@ func (e *EventStore) getConsolidatedBillableEventRows(tx *sql.Tx, filter eventio
 		order by event_guid
 	`, filterQuery), args...)
 	if err != nil {
+		e.logger.Error("get-consolidated-billable-event-rows-query", err, lager.Data{
+			"filter":  filter,
+			"elapsed": time.Since(startTime).String(),
+		})
 		return nil, err
 	}
+	e.logger.Info("get-consolidated-billable-event-rows-query", lager.Data{
+		"filter":  filter,
+		"elapsed": time.Since(startTime).String(),
+	})
 	return &BillableEventRows{rows}, nil
 }
 
@@ -129,13 +139,22 @@ func (e *EventStore) isRangeConsolidated(tx *sql.Tx, filter eventio.EventFilter)
 	if err := filter.Validate(); err != nil {
 		return false, err
 	}
+	startTime := time.Now()
 	rows, err := tx.Query(
 		"SELECT 1 FROM consolidation_history where consolidated_range=$1::tstzrange",
 		fmt.Sprintf("[%s, %s)", filter.RangeStart, filter.RangeStop),
 	)
 	if err != nil {
+		e.logger.Error("is-range-consolidated-query", err, lager.Data{
+			"filter":  filter,
+			"elapsed": time.Since(startTime).String(),
+		})
 		return false, err
 	}
+	e.logger.Info("is-range-consolidated-query", lager.Data{
+		"filter":  filter,
+		"elapsed": time.Since(startTime).String(),
+	})
 	defer rows.Close()
 	return rows.Next(), nil
 }
@@ -240,6 +259,7 @@ func (e *EventStore) consolidate(tx *sql.Tx, filter eventio.EventFilter) error {
 		return fmt.Errorf("consolidate must be called without an organisations filter (i.e. for all orgs)")
 	}
 
+	startTime := time.Now()
 	_, err := tx.Exec(`
 				insert into consolidation_history (
 					consolidated_range,
@@ -251,8 +271,16 @@ func (e *EventStore) consolidate(tx *sql.Tx, filter eventio.EventFilter) error {
 		fmt.Sprintf("[%s, %s)", filter.RangeStart, filter.RangeStop),
 		time.Now())
 	if err != nil {
+		e.logger.Error("consolidation-history-query", err, lager.Data{
+			"filter":  filter,
+			"elapsed": time.Since(startTime).String(),
+		})
 		return err
 	}
+	e.logger.Info("consolidation-history-query", lager.Data{
+		"filter":  filter,
+		"elapsed": time.Since(startTime).String(),
+	})
 
 	query, args, err := WithBillableEvents(`
 			insert into consolidated_billable_events (
@@ -301,10 +329,20 @@ func (e *EventStore) consolidate(tx *sql.Tx, filter eventio.EventFilter) error {
 	if err != nil {
 		return err
 	}
+
+	startTime = time.Now()
 	_, err = tx.Exec(query, args...)
 	if err != nil {
+		e.logger.Error("consolidation-insert-query", err, lager.Data{
+			"filter":  filter,
+			"elapsed": time.Since(startTime).String(),
+		})
 		return err
 	}
+	e.logger.Info("consolidation-insert-query", lager.Data{
+		"filter":  filter,
+		"elapsed": time.Since(startTime).String(),
+	})
 
 	return nil
 }

--- a/eventstore/store_consolidated_billable_events.go
+++ b/eventstore/store_consolidated_billable_events.go
@@ -84,16 +84,17 @@ func (e *EventStore) getConsolidatedBillableEventRows(tx *sql.Tx, filter eventio
 			%s
 		order by event_guid
 	`, filterQuery), args...)
+	elapsed := time.Since(startTime)
 	if err != nil {
 		e.logger.Error("get-consolidated-billable-event-rows-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return nil, err
 	}
 	e.logger.Info("get-consolidated-billable-event-rows-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 	return &BillableEventRows{rows}, nil
 }
@@ -144,16 +145,17 @@ func (e *EventStore) isRangeConsolidated(tx *sql.Tx, filter eventio.EventFilter)
 		"SELECT 1 FROM consolidation_history where consolidated_range=$1::tstzrange",
 		fmt.Sprintf("[%s, %s)", filter.RangeStart, filter.RangeStop),
 	)
+	elapsed := time.Since(startTime)
 	if err != nil {
 		e.logger.Error("is-range-consolidated-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return false, err
 	}
 	e.logger.Info("is-range-consolidated-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 	defer rows.Close()
 	return rows.Next(), nil
@@ -270,16 +272,17 @@ func (e *EventStore) consolidate(tx *sql.Tx, filter eventio.EventFilter) error {
 				)`,
 		fmt.Sprintf("[%s, %s)", filter.RangeStart, filter.RangeStop),
 		time.Now())
+	elapsed := time.Since(startTime)
 	if err != nil {
 		e.logger.Error("consolidation-history-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return err
 	}
 	e.logger.Info("consolidation-history-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 
 	query, args, err := WithBillableEvents(`
@@ -332,16 +335,17 @@ func (e *EventStore) consolidate(tx *sql.Tx, filter eventio.EventFilter) error {
 
 	startTime = time.Now()
 	_, err = tx.Exec(query, args...)
+	elapsed = time.Since(startTime)
 	if err != nil {
 		e.logger.Error("consolidation-insert-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return err
 	}
 	e.logger.Info("consolidation-insert-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 
 	return nil

--- a/eventstore/store_currency_rates.go
+++ b/eventstore/store_currency_rates.go
@@ -47,16 +47,17 @@ func (s *EventStore) GetCurrencyRates(filter eventio.TimeRangeFilter) ([]eventio
         order by
             valid_from
     `, filter.RangeStart, filter.RangeStop)
+	elapsed := time.Since(startTime)
 	if err != nil {
 		s.logger.Error("get-currency-rates-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return nil, err
 	}
 	s.logger.Info("get-currency-rates-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 
 	defer rows.Close()

--- a/eventstore/store_usage_events.go
+++ b/eventstore/store_usage_events.go
@@ -79,16 +79,17 @@ func (s *EventStore) getUsageEventRows(tx *sql.Tx, filter eventio.EventFilter) (
 		order by
 			lower(duration), event_guid
 	`, filterQuery), args...)
+	elapsed := time.Since(startTime)
 	if err != nil {
 		s.logger.Error("get-usage-event-rows-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return nil, err
 	}
 	s.logger.Info("get-usage-event-rows-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 	return &UsageEventRows{rows, tx}, nil
 }

--- a/eventstore/store_usage_events.go
+++ b/eventstore/store_usage_events.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/alphagov/paas-billing/eventio"
 )
 
@@ -48,6 +50,8 @@ func (s *EventStore) getUsageEventRows(tx *sql.Tx, filter eventio.EventFilter) (
 	if len(filterConditions) > 0 {
 		filterQuery = " and " + strings.Join(filterConditions, " and ")
 	}
+
+	startTime := time.Now()
 	rows, err := queryJSON(tx, fmt.Sprintf(`
 		select
 			event_guid,
@@ -76,8 +80,16 @@ func (s *EventStore) getUsageEventRows(tx *sql.Tx, filter eventio.EventFilter) (
 			lower(duration), event_guid
 	`, filterQuery), args...)
 	if err != nil {
+		s.logger.Error("get-usage-event-rows-query", err, lager.Data{
+			"filter":  filter,
+			"elapsed": time.Since(startTime).String(),
+		})
 		return nil, err
 	}
+	s.logger.Info("get-usage-event-rows-query", lager.Data{
+		"filter":  filter,
+		"elapsed": time.Since(startTime).String(),
+	})
 	return &UsageEventRows{rows, tx}, nil
 }
 

--- a/eventstore/store_vat_rates.go
+++ b/eventstore/store_vat_rates.go
@@ -47,16 +47,17 @@ func (s *EventStore) GetVATRates(filter eventio.TimeRangeFilter) ([]eventio.VATR
         order by
             valid_from
     `, filter.RangeStart, filter.RangeStop)
+	elapsed := time.Since(startTime)
 	if err != nil {
 		s.logger.Error("get-vat-rates-query", err, lager.Data{
 			"filter":  filter,
-			"elapsed": time.Since(startTime).String(),
+			"elapsed": int64(elapsed),
 		})
 		return nil, err
 	}
 	s.logger.Info("get-vat-rates-query", lager.Data{
 		"filter":  filter,
-		"elapsed": time.Since(startTime).String(),
+		"elapsed": int64(elapsed),
 	})
 
 	defer rows.Close()


### PR DESCRIPTION
What
----

This PR adds logging around the execution time of database queries and calls made to external APIs.

The only database queries whose execution time isn't logged are the Forecast Events–those are a bit awkward to log because it does lots of queries and it's not very important.

How to review
-----

Code review.

Who can review
-----

Not @46bit