### PR TITLE
Experimental optimization of create_events query

### DIFF
--- a/eventstore/sql/create_app_usage_events.sql
+++ b/eventstore/sql/create_app_usage_events.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS app_usage_events (
 CREATE INDEX IF NOT EXISTS app_usage_id_idx ON app_usage_events (id);
 CREATE INDEX IF NOT EXISTS app_usage_state_idx ON app_usage_events ( (raw_message->>'state') );
 CREATE INDEX IF NOT EXISTS app_usage_space_name_idx ON app_usage_events ( (raw_message->>'space_name') text_pattern_ops);
+CREATE INDEX IF NOT EXISTS app_usage_space_name_not_unbilled_idx ON app_usage_events ( (raw_message->>'space_name' !~ '^(SMOKE|ACC|CATS|PERF)-') );
 
 DO $$ BEGIN
 	ALTER TABLE app_usage_events ADD CONSTRAINT created_at_not_zero_value CHECK (created_at > 'epoch'::timestamptz);

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -39,9 +39,9 @@ INSERT INTO events_temp with
 				'app'::text as plan_name,                                  -- plan name for all compute resources
 				'4f6f0a18-cdd4-4e51-8b6b-dc39b696e61b'::uuid as service_guid,
 				'app'::text as service_name,
-				coalesce(raw_message->>'instance_count', '1')::numeric as number_of_nodes,
-				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::numeric as memory_in_mb,
-				'0'::numeric as storage_in_mb,
+				coalesce(raw_message->>'instance_count', '1')::integer as number_of_nodes,
+				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::integer as memory_in_mb,
+				'0'::integer as storage_in_mb,
 				(raw_message->>'state')::resource_state as state
 			from
 				app_usage_events
@@ -63,9 +63,9 @@ INSERT INTO events_temp with
 				(raw_message->>'service_plan_name') as plan_name,
 				(raw_message->>'service_guid')::uuid as service_guid,
 				(raw_message->>'service_label') as service_name,
-				NULL::numeric as number_of_nodes,
-				NULL::numeric as memory_in_mb,
-				NULL::numeric as storage_in_mb,
+				NULL::integer as number_of_nodes,
+				NULL::integer as memory_in_mb,
+				NULL::integer as storage_in_mb,
 				(case
 					when (raw_message->>'state') = 'CREATED' then 'STARTED'
 					when (raw_message->>'state') = 'DELETED' then 'STOPPED'
@@ -91,9 +91,9 @@ INSERT INTO events_temp with
 				'task'::text as plan_name,                                  -- plan name for all task resources
 				'4f6f0a18-cdd4-4e51-8b6b-dc39b696e61b'::uuid as service_guid,
 				'app'::text as service_name,
-				coalesce(raw_message->>'instance_count', '1')::numeric as number_of_nodes,
-				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::numeric as memory_in_mb,
-				'0'::numeric as storage_in_mb,
+				coalesce(raw_message->>'instance_count', '1')::integer as number_of_nodes,
+				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::integer as memory_in_mb,
+				'0'::integer as storage_in_mb,
 				(case
 					when (raw_message->>'state') = 'TASK_STARTED' then 'STARTED'
 					when (raw_message->>'state') = 'TASK_STOPPED' then 'STOPPED'
@@ -118,9 +118,9 @@ INSERT INTO events_temp with
 				'staging'::text as plan_name,                                  -- plan name for all staging of resources
 				'4f6f0a18-cdd4-4e51-8b6b-dc39b696e61b'::uuid as service_guid,
 				'app'::text as service_name,
-				'1'::numeric as number_of_nodes,
-				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::numeric as memory_in_mb,
-				'0'::numeric as storage_in_mb,
+				'1'::integer as number_of_nodes,
+				coalesce(raw_message->>'memory_in_mb_per_instance', '0')::integer as memory_in_mb,
+				'0'::integer as storage_in_mb,
 				(case
 					when (raw_message->>'state') = 'STAGING_STARTED' then 'STARTED'
 					when (raw_message->>'state') = 'STAGING_STOPPED' then 'STOPPED'
@@ -151,9 +151,9 @@ INSERT INTO events_temp with
 				(s.raw_message->>'service_plan_name') as plan_name,
 				(s.raw_message->>'service_guid')::uuid as service_guid,
 				(s.raw_message->>'service_label') as service_name,
-				NULL::numeric as number_of_nodes,
-				(pg_size_bytes(c.raw_message->'data'->>'memory') / 1024 / 1024)::numeric as memory_in_mb,
-				(pg_size_bytes(c.raw_message->'data'->>'storage') / 1024 / 1024)::numeric as storage_in_mb,
+				NULL::integer as number_of_nodes,
+				(pg_size_bytes(c.raw_message->'data'->>'memory') / 1024 / 1024)::integer as memory_in_mb,
+				(pg_size_bytes(c.raw_message->'data'->>'storage') / 1024 / 1024)::integer as storage_in_mb,
 				'STARTED'::resource_state as state
 			from
 				compose_audit_events c

--- a/eventstore/sql/create_service_usage_events.sql
+++ b/eventstore/sql/create_service_usage_events.sql
@@ -9,3 +9,4 @@ CREATE INDEX IF NOT EXISTS service_usage_id_idx ON service_usage_events (id);
 CREATE INDEX IF NOT EXISTS service_usage_state_idx ON service_usage_events ( (raw_message->>'state') );
 CREATE INDEX IF NOT EXISTS service_usage_type_idx ON service_usage_events ( (raw_message->>'service_instance_type') );
 CREATE INDEX IF NOT EXISTS service_usage_space_name_idx ON service_usage_events ( (raw_message->>'space_name') text_pattern_ops);
+CREATE INDEX IF NOT EXISTS service_usage_space_name_not_unbilled_idx ON service_usage_events ( (raw_message->>'space_name' !~ '^(SMOKE|ACC|CATS|PERF)-') );


### PR DESCRIPTION
Humour me.

This isn't so much meant for merge, but I'd be very interested to know if, run against a database and dataset that I don't have, the following changes make any improvement to the query time of the large `INSERT` statement...

The two changes are independent so should be testable separately if so desired...