### PR TITLE
Always rollback forecast event transactions

### DIFF
--- a/eventstore/store_forecast_events.go
+++ b/eventstore/store_forecast_events.go
@@ -22,9 +22,9 @@ func (s *EventStore) ForecastBillableEventRows(ctx context.Context, events []eve
 	if err != nil {
 		return nil, err
 	}
+	defer tx.Rollback()
 	rows, err := s.forecastBillableEventRows(tx, events, filter)
 	if err != nil {
-		tx.Rollback()
 		return nil, err
 	}
 	return rows, nil


### PR DESCRIPTION
What
----

At the moment we only roll the transaction back if there's an error
doing the forecast. We actually always want to roll back, since we
should never be committing test data into the events table (there's
already [a test](https://github.com/alphagov/paas-billing/blob/0b28e0b3f0aa677e989de87e1d44f3a5c3b11ca2/eventstore/store_forecast_events_test.go#L186-L236) for this.

We don't think this is the cause of our performance issues, the idle
transactions will probably just time out. Nevertheless it's better to
have the code do the right thing.

How to review
-----

* Code review
* Check the tests pass
* (that's probably enough)

Who can review
-----

Not @richardtowers