### PR TITLE
[#169035672] Allow a new exchange rate on any day

### DIFF
--- a/eventstore/store_currency_rates_test.go
+++ b/eventstore/store_currency_rates_test.go
@@ -25,14 +25,19 @@ var _ = Describe("GetCurrencyRates", func() {
 			},
 			CurrencyRates: []eventio.CurrencyRate{
 				{
+					Code:      "GBP",
+					Rate:      1,
+					ValidFrom: "1970-01-01T00:00:00+00:00",
+				},
+				{
 					Code:      "USD",
 					Rate:      0.8,
 					ValidFrom: "1970-01-01T00:00:00+00:00",
 				},
 				{
-					Code:      "GBP",
-					Rate:      1,
-					ValidFrom: "1970-01-01T00:00:00+00:00",
+					Code:      "USD",
+					Rate:      0.74,
+					ValidFrom: "2003-01-14T00:00:00+00:00",
 				},
 			},
 			PricingPlans: []eventio.PricingPlan{


### PR DESCRIPTION
What
----

In https://github.com/alphagov/paas-cf/pull/2110 and https://github.com/alphagov/paas-cf/pull/2111 we tried to change the USD–GBP exchange rate that we use. This failed because of a constraint requiring currency rates to take effect at midnight at the start of a month:

```
new row for relation "currency_rates" violates check constraint "valid_from_start_of_month"
```

This PR removes the requirement that currency rates are only changed at midnight at the start of the month. We will then be able to change currency rates on any day. They still have to take effect at midnight, to make things easier for any future improvements we make to billing.

How to review
-----

* See if the tests go green;
* Code review;
* Deploy to your dev env after deploying https://github.com/alphagov/paas-cf/pull/2111. Restart `paas-billing-collector` a few times and check it doesn't error.

Who can review
-----

Not @46bit.