### PR TITLE
Add usage and adoption queries

### DIFF
--- a/scripts/usage-and-adoption-generate-csv.sql
+++ b/scripts/usage-and-adoption-generate-csv.sql
@@ -1,0 +1,90 @@
+-- When creating or recreating a usage and adoption spreadsheet
+-- this file can be used to query the data
+
+-- To generate a CSV via the psql utility you can:
+--
+-- * Use "\a" to ensure your output is unaligned
+-- * Use "\f ," to output the results separated by commas
+-- * Use "\o /tmp/results-ireland.csv" to save the output in a CSV
+-- * Use "\i scripts/usage-and-adoption-generate-csv.sql" to run this query
+
+WITH
+distinct_orgs_first_seen AS (
+  SELECT
+    DISTINCT ON (org_guid)
+      org_guid,
+      LAST_VALUE(org_name)
+        OVER (
+          PARTITION BY (org_guid)
+          ORDER BY LOWER(duration) ASC
+          RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        )
+      AS org_name,
+      FIRST_VALUE(LOWER(duration)::date)
+        OVER (
+          PARTITION BY (org_guid)
+          ORDER BY LOWER(duration) ASC
+          RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        )
+      AS seen
+  FROM billable_event_components
+),
+org_bills_by_plan_by_month AS
+  (SELECT date_trunc('month', DAY)::date AS mon,
+          'london' AS region,
+          org_guid,
+          CASE
+              WHEN plan_name = 'app' THEN 'compute'
+              WHEN plan_name = 'staging' THEN 'compute'
+              WHEN plan_name = 'task' THEN 'compute'
+              WHEN plan_name ~ 'postgres.*' THEN 'postgres'
+              WHEN plan_name ~ 'mysql.*' THEN 'mysql'
+              WHEN plan_name ~ 'elasticsearch.*' THEN 'elasticsearch'
+              WHEN plan_name ~ 'influx.*' THEN 'influxdb'
+              WHEN plan_name ~ 'redis.*' THEN 'redis'
+              WHEN plan_name ~ 'aws-s3.*' THEN 's3'
+              ELSE plan_name::text
+          END AS service,
+          sum(cost) AS total_cost
+   FROM tmp_billable_event_components_by_day
+   GROUP BY mon, region, org_guid, service
+),
+aggregated_org_bills_by_plan_by_month AS (
+  SELECT mon,
+         region,
+         org_guid,
+         jsonb_object(array_agg(service), array_agg(total_cost::text)) AS service_costs
+   FROM org_bills_by_plan_by_month
+   GROUP BY mon, region, org_guid
+)
+SELECT mon,
+       '' as department,
+       region,
+       aggregated_org_bills_by_plan_by_month.org_guid,
+       org_name,
+       seen::date AS first_seen,
+       COALESCE(service_costs->>'compute', '0') AS compute,
+       COALESCE(service_costs->>'postgres', '0') AS postgres,
+       COALESCE(service_costs->>'mysql', '0') AS mysql,
+       COALESCE(service_costs->>'elasticsearch', '0') AS elasticsearch,
+       COALESCE(service_costs->>'redis', '0') AS redis,
+       COALESCE(service_costs->>'s3', '0') AS s3,
+       COALESCE(service_costs->>'influxdb', '0') AS influxdb,
+
+       COALESCE(service_costs->>'compute', '0')::numeric
+       + COALESCE(service_costs->>'postgres', '0')::numeric
+       + COALESCE(service_costs->>'mysql', '0')::numeric
+       + COALESCE(service_costs->>'elasticsearch', '0')::numeric
+       + COALESCE(service_costs->>'redis', '0')::numeric
+       + COALESCE(service_costs->>'s3', '0')::numeric
+       + COALESCE(service_costs->>'influxdb', '0')::numeric
+       AS total
+FROM aggregated_org_bills_by_plan_by_month JOIN distinct_orgs_first_seen
+ON aggregated_org_bills_by_plan_by_month.org_guid = distinct_orgs_first_seen.org_guid
+WHERE true
+      AND org_name NOT LIKE 'AIVENBACC%'
+      AND org_name NOT LIKE 'BACC%'
+      AND org_name NOT LIKE 'ACC%'
+      AND org_name NOT LIKE 'SMOKE%'
+      AND org_name !~* '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+ORDER BY mon ASC

--- a/scripts/usage-and-adoption-recreate.sql
+++ b/scripts/usage-and-adoption-recreate.sql
@@ -1,0 +1,142 @@
+-- When creating or recreating a usage and adoption spreadsheet
+-- this file can be used to create the tables in an idempotent fashion
+
+DROP TABLE IF EXISTS tmp_billable_event_components_by_day;
+
+CREATE TABLE IF NOT EXISTS tmp_billable_event_components_by_day AS
+WITH
+  billable_event_components_we_want AS (
+    SELECT *
+    FROM billable_event_components
+  ),
+
+  billable_event_component_series AS (
+    SELECT
+      event_guid,
+
+      resource_guid, resource_name, resource_type,
+
+      org_guid, org_name,
+
+      space_guid, space_name,
+
+      plan_guid, plan_valid_from, plan_name,
+
+      number_of_nodes, memory_in_mb, storage_in_mb,
+
+      component_name, component_formula,
+
+      currency_code, currency_rate,
+
+      vat_code, vat_rate,
+
+      cost_for_duration, duration,
+
+      -- unroll event duration (start -> end) into rows where each row is a day
+      -- so we can group and query by day and by month using a regular index
+      GENERATE_SERIES(
+        LOWER(duration),
+        UPPER(duration),
+        '1 day'::interval
+      ) AS day
+
+    FROM billable_event_components_we_want
+  ),
+
+  costed_billable_event_component_series AS (
+    SELECT
+      event_guid,
+
+      resource_guid, resource_name, resource_type,
+
+      org_guid, org_name,
+
+      space_guid, space_name,
+
+      plan_guid, plan_valid_from, plan_name,
+
+      number_of_nodes, memory_in_mb, storage_in_mb,
+
+      component_name, component_formula,
+
+      currency_code, currency_rate,
+
+      vat_code, vat_rate,
+
+      cost_for_duration, duration,
+
+      day::date as day,
+
+      -- intersect whole day and duration to get minimal complete event
+      -- duration for day
+      TSTZRANGE(
+        DATE_TRUNC('day', day),
+        DATE_TRUNC('day', day) + INTERVAL '1 day' - INTERVAL '1 second',
+        '[]'
+      ) * duration AS day_duration
+
+    FROM billable_event_component_series
+  ),
+
+  daily_costed_billable_event_components AS (
+    SELECT
+      day,
+
+      event_guid,
+
+      resource_guid, resource_name, resource_type,
+
+      org_guid, org_name,
+
+      space_guid, space_name,
+
+      plan_guid, plan_valid_from, plan_name,
+
+      number_of_nodes, memory_in_mb, storage_in_mb,
+
+      component_name, component_formula,
+
+      currency_code, currency_rate,
+
+      vat_code, vat_rate,
+
+      cost_for_duration, duration, day_duration,
+
+      -- compute cost for this event for this day
+      -- $duration_seconds_of_day_event / $duration_seconds_of_event
+      -- we are losing millisecond precision here
+      (
+        EXTRACT(EPOCH FROM (UPPER(day_duration) - LOWER(day_duration)))
+      ) / (
+        EXTRACT(EPOCH FROM (UPPER(duration) - LOWER(duration)))
+      ) * cost_for_duration AS cost
+
+    FROM costed_billable_event_component_series
+  )
+
+SELECT *
+FROM daily_costed_billable_event_components;
+
+CREATE INDEX
+    tmp_billable_event_components_by_day_day
+  ON
+    tmp_billable_event_components_by_day (day)
+;
+
+CREATE INDEX
+    tmp_billable_event_components_by_day_plan_guid
+  ON
+    tmp_billable_event_components_by_day (plan_guid)
+;
+
+CREATE INDEX
+    tmp_billable_event_components_by_day_org_guid
+  ON
+    tmp_billable_event_components_by_day (org_guid)
+;
+
+CREATE INDEX
+    tmp_billable_event_components_by_day_space_guid
+  ON
+    tmp_billable_event_components_by_day (space_guid)
+;


### PR DESCRIPTION
What
----

Each quarter, we would like to look at usage and adoption, and the billing database is a convenient source of data. However the billing database is not ergonomic to query quickly

This PR adds two SQL scripts:

* `scripts/usage-and-adoption-recreate.sql`
* `scripts/usage-and-adoption-generate-csv.sql`

which can be used to, respectively:

* set up the necessary tables for quick and ergonomic analysis
* generate a CSV usable by us and the PMO team within a spreadsheet

How to review
-----

In your development environment you should:

* Log in, and target the billing space: `cf target -o admin -s billing`
* Conduit into the billing database: `cf conduit billing-db -- psql`
* Generate the tables: `\i scripts/usage-and-adoption-recreate.sql`
* Generate the CSV: `\i scripts/usage-and-adoption-generate-csv.sql`

Who can review
-----

@poveyd @schmie 