### PR TITLE
[#175935956] Use Postgres 12 instead of 9.5 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: false
 
 language: go
@@ -6,11 +6,16 @@ language: go
 go:
   - 1.13
 
-services:
-  - postgresql
-
 addons:
-  postgresql: "9.5"
+  apt:
+    packages:
+      - postgresql-12
+      - postgresql-client-12
+
+before_install:
+  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/12/main/postgresql.conf
+  - sudo cp /etc/postgresql/{9.3,12}/main/pg_hba.conf
+  - sudo pg_ctlcluster 12 main restart
 
 install:
   # Prevent default install task that does a `go get -t ./...`

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean:
 	rm -f bin/paas-billing
 
 start_postgres_docker:
-	docker run --rm -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
+	docker run -p 5432:5432 --name postgres -e POSTGRES_HOST_AUTH_METHOD=trust -d postgres:12.5
 
 stop_postgres_docker:
 	docker stop postgres


### PR DESCRIPTION
What
----

Until now we've used Postgres 9.5 for the billing database in most of our environments. But Postgres 9.5 is being deprecated soon, so we're upgrading to Postgres 12.

This PR changes our tests so that they use Postgres 12. The setup in `travis.yml` is based on https://stackoverflow.com/a/62037133; nothing simpler worked.

How to review
-----

* Code review
* Known caveat: there seems to be some timezone weirdness when running the tests locally. Travis says some timestamps are the same but my local tests disagree. I'm not sure what to do about that, so I'm leaving it for now.

Who can review
-----

Anyone except @46bit

⚠️ You need to sign merges to this repo.