### PR TITLE
Increase DefaultRefreshTimeout

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -25,7 +25,7 @@ const (
 	TaskPlanGUID          = "ebfa9453-ef66-450c-8c37-d53dfd931038"
 	StagingPlanGUID       = "9d071c77-7a68-4346-9981-e8dafac95b6f"
 	DefaultInitTimeout    = 25 * time.Minute
-	DefaultRefreshTimeout = 25 * time.Minute
+	DefaultRefreshTimeout = 45 * time.Minute
 	DefaultStoreTimeout   = 45 * time.Second
 	DefaultQueryTimeout   = 45 * time.Second
 )

--- a/main_config.go
+++ b/main_config.go
@@ -98,7 +98,7 @@ func NewConfigFromEnv() (cfg Config, err error) {
 			FetchLimit:   getEnvWithDefaultInt("CF_FETCH_LIMIT", 50),
 		},
 		Processor: ProcessorConfig{
-			Schedule: getEnvWithDefaultDuration("PROCESSOR_SCHEDULE", 30*time.Minute),
+			Schedule: getEnvWithDefaultDuration("PROCESSOR_SCHEDULE", 60*time.Minute),
 		},
 		ServerPort: getEnvWithDefaultInt("PORT", 8881),
 	}

--- a/main_config_test.go
+++ b/main_config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Config", func() {
 		Expect(cfg.Collector.MinWaitTime).To(Equal(3 * time.Second))
 		Expect(cfg.CFFetcher.RecordMinAge).To(Equal(10 * time.Minute))
 		Expect(cfg.CFFetcher.FetchLimit).To(Equal(50))
-		Expect(cfg.Processor.Schedule).To(Equal(30 * time.Minute))
+		Expect(cfg.Processor.Schedule).To(Equal(60 * time.Minute))
 		Expect(cfg.ServerPort).To(Equal(8881))
 	})
 


### PR DESCRIPTION
What
----

The refresh function in prod london is timing out and currently fails when
running create_billable_event_components.sql. We're in the process of
reviewing billing so this increases the timeout to resolve the issue for now.

It also increases the processor schedule from 30 minutes to 1 hour.

How to review
-----

Code review

Who can review
-----

Not me
