### PR TITLE
Increase DefaultRefreshTimeout for event store

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -25,7 +25,7 @@ const (
 	TaskPlanGUID          = "ebfa9453-ef66-450c-8c37-d53dfd931038"
 	StagingPlanGUID       = "9d071c77-7a68-4346-9981-e8dafac95b6f"
 	DefaultInitTimeout    = 25 * time.Minute
-	DefaultRefreshTimeout = 45 * time.Minute
+	DefaultRefreshTimeout = 90 * time.Minute
 	DefaultStoreTimeout   = 45 * time.Second
 	DefaultQueryTimeout   = 45 * time.Second
 )

--- a/main_config.go
+++ b/main_config.go
@@ -98,7 +98,7 @@ func NewConfigFromEnv() (cfg Config, err error) {
 			FetchLimit:   getEnvWithDefaultInt("CF_FETCH_LIMIT", 50),
 		},
 		Processor: ProcessorConfig{
-			Schedule: getEnvWithDefaultDuration("PROCESSOR_SCHEDULE", 60*time.Minute),
+			Schedule: getEnvWithDefaultDuration("PROCESSOR_SCHEDULE", 120*time.Minute),
 		},
 		ServerPort: getEnvWithDefaultInt("PORT", 8881),
 	}

--- a/main_config_test.go
+++ b/main_config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Config", func() {
 		Expect(cfg.Collector.MinWaitTime).To(Equal(3 * time.Second))
 		Expect(cfg.CFFetcher.RecordMinAge).To(Equal(10 * time.Minute))
 		Expect(cfg.CFFetcher.FetchLimit).To(Equal(50))
-		Expect(cfg.Processor.Schedule).To(Equal(60 * time.Minute))
+		Expect(cfg.Processor.Schedule).To(Equal(120 * time.Minute))
 		Expect(cfg.ServerPort).To(Equal(8881))
 	})
 


### PR DESCRIPTION
What
----
The event store refresh is currently timinng out. This timeout increase is a temporary fix while work on refactoring is ongoing.
This change also requires to increase the processor schedule timeout to be larger than the refresh timeout.

How to review
-----

Code review

Who can review
-----
not @schmie 
