### PR TITLE
Force service_plan.unique ID to be a UUID

### DIFF
--- a/eventstore/sql/create_base_objects.sql
+++ b/eventstore/sql/create_base_objects.sql
@@ -200,3 +200,12 @@ CREATE TABLE pricing_plan_components (
 	CONSTRAINT formula_must_not_be_blank CHECK (length(trim(formula)) > 0)
 );
 CREATE TRIGGER tgr_ppc_validate_formula BEFORE INSERT OR UPDATE ON pricing_plan_components FOR EACH ROW EXECUTE PROCEDURE validate_formula();
+
+CREATE OR REPLACE FUNCTION uuid_or_placeholder(str text)
+RETURNS uuid AS $$
+BEGIN
+  RETURN str::uuid;
+EXCEPTION WHEN invalid_text_representation THEN
+  RETURN 'd5091c33-2f9d-4b15-82dc-4ad69717fc03'::uuid;
+END;
+$$ LANGUAGE plpgsql;

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -280,7 +280,7 @@ INSERT INTO events_temp with
 		duration,
 		(case
 			when resource_type = 'service'
-			then coalesce(vsp.unique_id, 'd5091c33-2f9d-4b15-82dc-4ad69717fc03')::uuid
+			then coalesce(uuid_or_placeholder(vsp.unique_id), 'd5091c33-2f9d-4b15-82dc-4ad69717fc03')::uuid
 			else plan_guid
 		end) as plan_guid,
 		coalesce(vsp.name, plan_name) as plan_name,


### PR DESCRIPTION
What
----

This commit introduces a function uuid_or_placeholder which replaces the unique_id field with a placeholder UUID 'd5091c33-2f9d-4b15-82dc-4ad69717fc03' which we also use in case of the unique_id being NULL.

pair: @poveyd @schmie

Why
----

The create_events.sql query assumes the service plan unique_id field to be a UUID / casts it to UUID without checks.
The unique_id is named so because it need not be a UUID, though.

We have encountered a case of a tenant using a custom broker (Vault broker) which will set unique_id of the form '<UUID>.shared'. The presence of such service_plan.unique_id breaks the generation of the events table in paas-billing.

Using a placeholder UUID is feasible as we are not currently using Vault broker for any billed services and do not care about these custom plans.
Also, work to replace this way of processing events is underway.

How to review
-----

- code review
- optionally: Access a copy of the billing-db spun up in prod-lon (`2021-04-21-copy-of-billing-db`) and manually run the create_events query via e.g. `\i paas-billing/eventstore/sql/create_event.sql` and verify it does not fail (was tested by @poveyd, @schmie).

Who can review
-----

Anyone