### PR TITLE
Add an owner column into the API

### DIFF
--- a/cfstore/cfstore.go
+++ b/cfstore/cfstore.go
@@ -241,19 +241,22 @@ func (s *Store) collectOrgs(tx *sql.Tx) error {
 				name,
 				created_at,
 				updated_at,
-				quota_definition_guid
+				quota_definition_guid,
+				owner
 			) values (
 				$1, $2,
 				$3,
 				$4,
 				$5,
-				$6
+				$6,
+				$7
 			) on conflict (guid, valid_from) do nothing`,
 			org.Guid, validFrom,
 			org.Name,
 			org.CreatedAt,
 			org.UpdatedAt,
-			org.QuotaDefinitionGuid,
+			org.Relationships.Quota.Data.Guid,
+			org.Metadata.Annotations.Owner,
 		)
 
 		if err != nil {

--- a/cfstore/cfstore_client.go
+++ b/cfstore/cfstore_client.go
@@ -1,17 +1,53 @@
 package cfstore
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
 	"github.com/cloudfoundry-community/go-cfclient"
 )
 
 type CFDataClient interface {
 	ListServicePlans() ([]cfclient.ServicePlan, error)
 	ListServices() ([]cfclient.Service, error)
-	ListOrgs() ([]cfclient.Org, error)
+	ListOrgs() ([]V3Org, error)
 	ListSpaces() ([]cfclient.Space, error)
 }
 
 var _ CFDataClient = &Client{}
+
+type V3OrgMetadataAnnotations struct {
+	Owner string `json:"owner"`
+}
+
+type V3OrgMetadata struct {
+	Annotations V3OrgMetadataAnnotations `json:"annotations"`
+}
+
+type V3OrgRelationshipsQuotaData struct {
+	Guid string `json:"guid"`
+}
+
+type V3OrgRelationshipsQuota struct {
+	Data V3OrgRelationshipsQuotaData `json:"data"`
+}
+
+type V3OrgRelationships struct {
+	Quota V3OrgRelationshipsQuota `json:"quota"`
+}
+
+type V3Org struct {
+	Guid          string             `json:"guid"`
+	Name          string             `json:"name"`
+	CreatedAt     string             `json:"created_at"`
+	UpdatedAt     string             `json:"updated_at"`
+	Metadata      V3OrgMetadata      `json:"metadata"`
+	Relationships V3OrgRelationships `json:"relationships"`
+}
+type V3OrgsResponse struct {
+	Resources []V3Org `json:"resources"`
+}
 
 type Client struct {
 	Client *cfclient.Client
@@ -25,8 +61,25 @@ func (c *Client) ListServices() ([]cfclient.Service, error) {
 	return c.Client.ListServices()
 }
 
-func (c *Client) ListOrgs() ([]cfclient.Org, error) {
-	return c.Client.ListOrgs()
+func (c *Client) ListOrgs() ([]V3Org, error) {
+	req := c.Client.NewRequest("GET", "/v3/organizations")
+	res, err := c.Client.DoRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to interact with v3 api gathering orgs: %v", err)
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read out body into bytes array: %v", err)
+	}
+
+	var orgsRes V3OrgsResponse
+	if err = json.Unmarshal(body, &orgsRes); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal json response into the struct: %v", err)
+	}
+
+	return orgsRes.Resources, nil
 }
 
 func (c *Client) ListSpaces() ([]cfclient.Space, error) {

--- a/cfstore/cfstore_collect_orgs_test.go
+++ b/cfstore/cfstore_collect_orgs_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/alphagov/paas-billing/cfstore"
 	"github.com/alphagov/paas-billing/fakes"
 	"github.com/alphagov/paas-billing/testenv"
-	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	. "github.com/onsi/ginkgo"
 
 	. "github.com/onsi/gomega"
@@ -25,7 +24,7 @@ var _ = Describe("Orgs", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		fakeClient = &fakes.FakeCFDataClient{}
-		fakeClient.ListOrgsReturnsOnCall(0, []cfclient.Org{}, nil)
+		fakeClient.ListOrgsReturnsOnCall(0, []cfstore.V3Org{}, nil)
 
 		store, err = cfstore.New(cfstore.Config{
 			Client: fakeClient,
@@ -40,26 +39,38 @@ var _ = Describe("Orgs", func() {
 	})
 
 	It("should collect org data", func() {
-		org1 := cfclient.Org{
-			Guid:                uuid.NewV4().String(),
-			Name:                "my-org",
-			CreatedAt:           "2001-01-01T01:01:01+00:00",
-			UpdatedAt:           "2002-02-02T02:02:02+00:00",
-			QuotaDefinitionGuid: uuid.NewV4().String(),
+		org1 := cfstore.V3Org{
+			Guid:      uuid.NewV4().String(),
+			Name:      "my-org",
+			CreatedAt: "2001-01-01T01:01:01+00:00",
+			UpdatedAt: "2002-02-02T02:02:02+00:00",
+			Metadata: cfstore.V3OrgMetadata{
+				Annotations: cfstore.V3OrgMetadataAnnotations{
+					Owner: "Testing Body",
+				},
+			},
+			Relationships: cfstore.V3OrgRelationships{
+				Quota: cfstore.V3OrgRelationshipsQuota{
+					Data: cfstore.V3OrgRelationshipsQuotaData{
+						Guid: uuid.NewV4().String(),
+					},
+				},
+			},
 		}
 
 		By("storing the data using the created_at date for the valid_from field initially")
-		fakeClient.ListOrgsReturnsOnCall(1, []cfclient.Org{
+		fakeClient.ListOrgsReturnsOnCall(1, []cfstore.V3Org{
 			org1,
 		}, nil)
 		Expect(store.CollectOrgs()).To(Succeed())
 		expectedFirstRow := testenv.Row{
 			"guid":                  org1.Guid,
 			"name":                  org1.Name,
+			"owner":                 org1.Metadata.Annotations.Owner,
 			"valid_from":            org1.CreatedAt,
 			"updated_at":            org1.UpdatedAt,
 			"created_at":            org1.CreatedAt,
-			"quota_definition_guid": org1.QuotaDefinitionGuid,
+			"quota_definition_guid": org1.Relationships.Quota.Data.Guid,
 		}
 		expectedResult1 := testenv.Rows{expectedFirstRow}
 		Expect(tempdb.Query(`select * from orgs`)).To(MatchJSON(expectedResult1))
@@ -69,44 +80,57 @@ var _ = Describe("Orgs", func() {
 			"guid":                  org1.Guid,
 			"name":                  org1.Name,
 			"valid_from":            org1.UpdatedAt, // THIS IS THE DIFFERENCE FROM 1stROW ^^
+			"owner":                 org1.Metadata.Annotations.Owner,
 			"updated_at":            org1.UpdatedAt,
 			"created_at":            org1.CreatedAt,
-			"quota_definition_guid": org1.QuotaDefinitionGuid,
+			"quota_definition_guid": org1.Relationships.Quota.Data.Guid,
 		}
 		expectedResult2 := testenv.Rows{expectedFirstRow, expectedSecondRow}
 
-		fakeClient.ListOrgsReturnsOnCall(2, []cfclient.Org{
+		fakeClient.ListOrgsReturnsOnCall(2, []cfstore.V3Org{
 			org1,
 		}, nil)
 		Expect(store.CollectOrgs()).To(Succeed())
 		Expect(tempdb.Query(`select * from orgs`)).To(MatchJSON(expectedResult2))
 
 		By("not changing any data when the stored valid_from date matches the updated_at field during all subsequent operations")
-		fakeClient.ListOrgsReturnsOnCall(3, []cfclient.Org{
+		fakeClient.ListOrgsReturnsOnCall(3, []cfstore.V3Org{
 			org1,
 		}, nil)
 		Expect(store.CollectOrgs()).To(Succeed())
 		Expect(tempdb.Query(`select * from orgs`)).To(MatchJSON(expectedResult2))
 
 		By("storing updates to the org")
-		org2 := cfclient.Org{
-			Guid:                org1.Guid,
-			Name:                "my-org",
-			CreatedAt:           "2001-01-01T01:01:01+00:00",
-			UpdatedAt:           "2003-03-03T03:03:03+00:00",
-			QuotaDefinitionGuid: org1.QuotaDefinitionGuid,
+		org2 := cfstore.V3Org{
+			Guid:      org1.Guid,
+			Name:      "my-org",
+			CreatedAt: "2001-01-01T01:01:01+00:00",
+			UpdatedAt: "2003-03-03T03:03:03+00:00",
+			Metadata: cfstore.V3OrgMetadata{
+				Annotations: cfstore.V3OrgMetadataAnnotations{
+					Owner: "Testing Body 2",
+				},
+			},
+			Relationships: cfstore.V3OrgRelationships{
+				Quota: cfstore.V3OrgRelationshipsQuota{
+					Data: cfstore.V3OrgRelationshipsQuotaData{
+						Guid: uuid.NewV4().String(),
+					},
+				},
+			},
 		}
-		fakeClient.ListOrgsReturnsOnCall(4, []cfclient.Org{
+		fakeClient.ListOrgsReturnsOnCall(4, []cfstore.V3Org{
 			org2,
 		}, nil)
 		Expect(store.CollectOrgs()).To(Succeed())
 		expectedThirdRow := testenv.Row{
 			"guid":                  org2.Guid,
 			"name":                  org2.Name,
+			"owner":                 org2.Metadata.Annotations.Owner,
 			"valid_from":            org2.UpdatedAt,
 			"updated_at":            org2.UpdatedAt,
 			"created_at":            org2.CreatedAt,
-			"quota_definition_guid": org2.QuotaDefinitionGuid,
+			"quota_definition_guid": org2.Relationships.Quota.Data.Guid,
 		}
 		expectedResult3 := testenv.Rows{
 			expectedFirstRow,

--- a/eventstore/sql/2021-05-06-alter_orgs.sql
+++ b/eventstore/sql/2021-05-06-alter_orgs.sql
@@ -1,0 +1,1 @@
+alter table orgs add column if not exists owner text not null check (length(name)>0);

--- a/eventstore/sql/create_orgs.sql
+++ b/eventstore/sql/create_orgs.sql
@@ -2,6 +2,7 @@ create table if not exists orgs (
 	guid uuid not null,
 	valid_from timestamptz not null,
 	name text not null check (length(name)>0),
+	owner text not null check (length(name)>0),
 	created_at timestamptz not null,
 	updated_at timestamptz not null,
 	quota_definition_guid uuid,

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -75,6 +75,7 @@ func (s *EventStore) Init() error {
 		"create_base_objects.sql",
 		"create_orgs.sql",
 		"create_spaces.sql",
+		"2021-05-06-alter_orgs.sql",
 	}
 	for _, sqlFile := range sqlFiles {
 		err := s.runSQLFile(tx, sqlFile)

--- a/eventstore/store_usage_events_test.go
+++ b/eventstore/store_usage_events_test.go
@@ -1137,6 +1137,7 @@ var _ = Describe("GetUsageEvents", func() {
 			"guid":                  "51ba75ef-edc0-47ad-a633-a8f6e8770944",
 			"valid_from":            "2000-01-01T00:00:00Z",
 			"name":                  "my-org",
+			"owner":                 "Testing Body",
 			"created_at":            "2000-01-01T00:00:00Z",
 			"updated_at":            "2018-06-14T16:32:38Z",
 			"quota_definition_guid": "f9909cea-81fe-4934-ba17-2a10278d2646",

--- a/fakes/fake_cf_data_client.go
+++ b/fakes/fake_cf_data_client.go
@@ -9,10 +9,23 @@ import (
 )
 
 type FakeCFDataClient struct {
+	ListOrgsStub        func() ([]cfstore.V3Org, error)
+	listOrgsMutex       sync.RWMutex
+	listOrgsArgsForCall []struct {
+	}
+	listOrgsReturns struct {
+		result1 []cfstore.V3Org
+		result2 error
+	}
+	listOrgsReturnsOnCall map[int]struct {
+		result1 []cfstore.V3Org
+		result2 error
+	}
 	ListServicePlansStub        func() ([]cfclient.ServicePlan, error)
 	listServicePlansMutex       sync.RWMutex
-	listServicePlansArgsForCall []struct{}
-	listServicePlansReturns     struct {
+	listServicePlansArgsForCall []struct {
+	}
+	listServicePlansReturns struct {
 		result1 []cfclient.ServicePlan
 		result2 error
 	}
@@ -22,8 +35,9 @@ type FakeCFDataClient struct {
 	}
 	ListServicesStub        func() ([]cfclient.Service, error)
 	listServicesMutex       sync.RWMutex
-	listServicesArgsForCall []struct{}
-	listServicesReturns     struct {
+	listServicesArgsForCall []struct {
+	}
+	listServicesReturns struct {
 		result1 []cfclient.Service
 		result2 error
 	}
@@ -31,21 +45,11 @@ type FakeCFDataClient struct {
 		result1 []cfclient.Service
 		result2 error
 	}
-	ListOrgsStub        func() ([]cfclient.Org, error)
-	listOrgsMutex       sync.RWMutex
-	listOrgsArgsForCall []struct{}
-	listOrgsReturns     struct {
-		result1 []cfclient.Org
-		result2 error
-	}
-	listOrgsReturnsOnCall map[int]struct {
-		result1 []cfclient.Org
-		result2 error
-	}
 	ListSpacesStub        func() ([]cfclient.Space, error)
 	listSpacesMutex       sync.RWMutex
-	listSpacesArgsForCall []struct{}
-	listSpacesReturns     struct {
+	listSpacesArgsForCall []struct {
+	}
+	listSpacesReturns struct {
 		result1 []cfclient.Space
 		result2 error
 	}
@@ -57,19 +61,78 @@ type FakeCFDataClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCFDataClient) ListServicePlans() ([]cfclient.ServicePlan, error) {
-	fake.listServicePlansMutex.Lock()
-	ret, specificReturn := fake.listServicePlansReturnsOnCall[len(fake.listServicePlansArgsForCall)]
-	fake.listServicePlansArgsForCall = append(fake.listServicePlansArgsForCall, struct{}{})
-	fake.recordInvocation("ListServicePlans", []interface{}{})
-	fake.listServicePlansMutex.Unlock()
-	if fake.ListServicePlansStub != nil {
-		return fake.ListServicePlansStub()
+func (fake *FakeCFDataClient) ListOrgs() ([]cfstore.V3Org, error) {
+	fake.listOrgsMutex.Lock()
+	ret, specificReturn := fake.listOrgsReturnsOnCall[len(fake.listOrgsArgsForCall)]
+	fake.listOrgsArgsForCall = append(fake.listOrgsArgsForCall, struct {
+	}{})
+	stub := fake.ListOrgsStub
+	fakeReturns := fake.listOrgsReturns
+	fake.recordInvocation("ListOrgs", []interface{}{})
+	fake.listOrgsMutex.Unlock()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listServicePlansReturns.result1, fake.listServicePlansReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCFDataClient) ListOrgsCallCount() int {
+	fake.listOrgsMutex.RLock()
+	defer fake.listOrgsMutex.RUnlock()
+	return len(fake.listOrgsArgsForCall)
+}
+
+func (fake *FakeCFDataClient) ListOrgsCalls(stub func() ([]cfstore.V3Org, error)) {
+	fake.listOrgsMutex.Lock()
+	defer fake.listOrgsMutex.Unlock()
+	fake.ListOrgsStub = stub
+}
+
+func (fake *FakeCFDataClient) ListOrgsReturns(result1 []cfstore.V3Org, result2 error) {
+	fake.listOrgsMutex.Lock()
+	defer fake.listOrgsMutex.Unlock()
+	fake.ListOrgsStub = nil
+	fake.listOrgsReturns = struct {
+		result1 []cfstore.V3Org
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCFDataClient) ListOrgsReturnsOnCall(i int, result1 []cfstore.V3Org, result2 error) {
+	fake.listOrgsMutex.Lock()
+	defer fake.listOrgsMutex.Unlock()
+	fake.ListOrgsStub = nil
+	if fake.listOrgsReturnsOnCall == nil {
+		fake.listOrgsReturnsOnCall = make(map[int]struct {
+			result1 []cfstore.V3Org
+			result2 error
+		})
+	}
+	fake.listOrgsReturnsOnCall[i] = struct {
+		result1 []cfstore.V3Org
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCFDataClient) ListServicePlans() ([]cfclient.ServicePlan, error) {
+	fake.listServicePlansMutex.Lock()
+	ret, specificReturn := fake.listServicePlansReturnsOnCall[len(fake.listServicePlansArgsForCall)]
+	fake.listServicePlansArgsForCall = append(fake.listServicePlansArgsForCall, struct {
+	}{})
+	stub := fake.ListServicePlansStub
+	fakeReturns := fake.listServicePlansReturns
+	fake.recordInvocation("ListServicePlans", []interface{}{})
+	fake.listServicePlansMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCFDataClient) ListServicePlansCallCount() int {
@@ -78,7 +141,15 @@ func (fake *FakeCFDataClient) ListServicePlansCallCount() int {
 	return len(fake.listServicePlansArgsForCall)
 }
 
+func (fake *FakeCFDataClient) ListServicePlansCalls(stub func() ([]cfclient.ServicePlan, error)) {
+	fake.listServicePlansMutex.Lock()
+	defer fake.listServicePlansMutex.Unlock()
+	fake.ListServicePlansStub = stub
+}
+
 func (fake *FakeCFDataClient) ListServicePlansReturns(result1 []cfclient.ServicePlan, result2 error) {
+	fake.listServicePlansMutex.Lock()
+	defer fake.listServicePlansMutex.Unlock()
 	fake.ListServicePlansStub = nil
 	fake.listServicePlansReturns = struct {
 		result1 []cfclient.ServicePlan
@@ -87,6 +158,8 @@ func (fake *FakeCFDataClient) ListServicePlansReturns(result1 []cfclient.Service
 }
 
 func (fake *FakeCFDataClient) ListServicePlansReturnsOnCall(i int, result1 []cfclient.ServicePlan, result2 error) {
+	fake.listServicePlansMutex.Lock()
+	defer fake.listServicePlansMutex.Unlock()
 	fake.ListServicePlansStub = nil
 	if fake.listServicePlansReturnsOnCall == nil {
 		fake.listServicePlansReturnsOnCall = make(map[int]struct {
@@ -103,16 +176,19 @@ func (fake *FakeCFDataClient) ListServicePlansReturnsOnCall(i int, result1 []cfc
 func (fake *FakeCFDataClient) ListServices() ([]cfclient.Service, error) {
 	fake.listServicesMutex.Lock()
 	ret, specificReturn := fake.listServicesReturnsOnCall[len(fake.listServicesArgsForCall)]
-	fake.listServicesArgsForCall = append(fake.listServicesArgsForCall, struct{}{})
+	fake.listServicesArgsForCall = append(fake.listServicesArgsForCall, struct {
+	}{})
+	stub := fake.ListServicesStub
+	fakeReturns := fake.listServicesReturns
 	fake.recordInvocation("ListServices", []interface{}{})
 	fake.listServicesMutex.Unlock()
-	if fake.ListServicesStub != nil {
-		return fake.ListServicesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listServicesReturns.result1, fake.listServicesReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCFDataClient) ListServicesCallCount() int {
@@ -121,7 +197,15 @@ func (fake *FakeCFDataClient) ListServicesCallCount() int {
 	return len(fake.listServicesArgsForCall)
 }
 
+func (fake *FakeCFDataClient) ListServicesCalls(stub func() ([]cfclient.Service, error)) {
+	fake.listServicesMutex.Lock()
+	defer fake.listServicesMutex.Unlock()
+	fake.ListServicesStub = stub
+}
+
 func (fake *FakeCFDataClient) ListServicesReturns(result1 []cfclient.Service, result2 error) {
+	fake.listServicesMutex.Lock()
+	defer fake.listServicesMutex.Unlock()
 	fake.ListServicesStub = nil
 	fake.listServicesReturns = struct {
 		result1 []cfclient.Service
@@ -130,6 +214,8 @@ func (fake *FakeCFDataClient) ListServicesReturns(result1 []cfclient.Service, re
 }
 
 func (fake *FakeCFDataClient) ListServicesReturnsOnCall(i int, result1 []cfclient.Service, result2 error) {
+	fake.listServicesMutex.Lock()
+	defer fake.listServicesMutex.Unlock()
 	fake.ListServicesStub = nil
 	if fake.listServicesReturnsOnCall == nil {
 		fake.listServicesReturnsOnCall = make(map[int]struct {
@@ -143,62 +229,22 @@ func (fake *FakeCFDataClient) ListServicesReturnsOnCall(i int, result1 []cfclien
 	}{result1, result2}
 }
 
-func (fake *FakeCFDataClient) ListOrgs() ([]cfclient.Org, error) {
-	fake.listOrgsMutex.Lock()
-	ret, specificReturn := fake.listOrgsReturnsOnCall[len(fake.listOrgsArgsForCall)]
-	fake.listOrgsArgsForCall = append(fake.listOrgsArgsForCall, struct{}{})
-	fake.recordInvocation("ListOrgs", []interface{}{})
-	fake.listOrgsMutex.Unlock()
-	if fake.ListOrgsStub != nil {
-		return fake.ListOrgsStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.listOrgsReturns.result1, fake.listOrgsReturns.result2
-}
-
-func (fake *FakeCFDataClient) ListOrgsCallCount() int {
-	fake.listOrgsMutex.RLock()
-	defer fake.listOrgsMutex.RUnlock()
-	return len(fake.listOrgsArgsForCall)
-}
-
-func (fake *FakeCFDataClient) ListOrgsReturns(result1 []cfclient.Org, result2 error) {
-	fake.ListOrgsStub = nil
-	fake.listOrgsReturns = struct {
-		result1 []cfclient.Org
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCFDataClient) ListOrgsReturnsOnCall(i int, result1 []cfclient.Org, result2 error) {
-	fake.ListOrgsStub = nil
-	if fake.listOrgsReturnsOnCall == nil {
-		fake.listOrgsReturnsOnCall = make(map[int]struct {
-			result1 []cfclient.Org
-			result2 error
-		})
-	}
-	fake.listOrgsReturnsOnCall[i] = struct {
-		result1 []cfclient.Org
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeCFDataClient) ListSpaces() ([]cfclient.Space, error) {
 	fake.listSpacesMutex.Lock()
 	ret, specificReturn := fake.listSpacesReturnsOnCall[len(fake.listSpacesArgsForCall)]
-	fake.listSpacesArgsForCall = append(fake.listSpacesArgsForCall, struct{}{})
+	fake.listSpacesArgsForCall = append(fake.listSpacesArgsForCall, struct {
+	}{})
+	stub := fake.ListSpacesStub
+	fakeReturns := fake.listSpacesReturns
 	fake.recordInvocation("ListSpaces", []interface{}{})
 	fake.listSpacesMutex.Unlock()
-	if fake.ListSpacesStub != nil {
-		return fake.ListSpacesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listSpacesReturns.result1, fake.listSpacesReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCFDataClient) ListSpacesCallCount() int {
@@ -207,7 +253,15 @@ func (fake *FakeCFDataClient) ListSpacesCallCount() int {
 	return len(fake.listSpacesArgsForCall)
 }
 
+func (fake *FakeCFDataClient) ListSpacesCalls(stub func() ([]cfclient.Space, error)) {
+	fake.listSpacesMutex.Lock()
+	defer fake.listSpacesMutex.Unlock()
+	fake.ListSpacesStub = stub
+}
+
 func (fake *FakeCFDataClient) ListSpacesReturns(result1 []cfclient.Space, result2 error) {
+	fake.listSpacesMutex.Lock()
+	defer fake.listSpacesMutex.Unlock()
 	fake.ListSpacesStub = nil
 	fake.listSpacesReturns = struct {
 		result1 []cfclient.Space
@@ -216,6 +270,8 @@ func (fake *FakeCFDataClient) ListSpacesReturns(result1 []cfclient.Space, result
 }
 
 func (fake *FakeCFDataClient) ListSpacesReturnsOnCall(i int, result1 []cfclient.Space, result2 error) {
+	fake.listSpacesMutex.Lock()
+	defer fake.listSpacesMutex.Unlock()
 	fake.ListSpacesStub = nil
 	if fake.listSpacesReturnsOnCall == nil {
 		fake.listSpacesReturnsOnCall = make(map[int]struct {
@@ -232,12 +288,12 @@ func (fake *FakeCFDataClient) ListSpacesReturnsOnCall(i int, result1 []cfclient.
 func (fake *FakeCFDataClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.listOrgsMutex.RLock()
+	defer fake.listOrgsMutex.RUnlock()
 	fake.listServicePlansMutex.RLock()
 	defer fake.listServicePlansMutex.RUnlock()
 	fake.listServicesMutex.RLock()
 	defer fake.listServicesMutex.RUnlock()
-	fake.listOrgsMutex.RLock()
-	defer fake.listOrgsMutex.RUnlock()
 	fake.listSpacesMutex.RLock()
 	defer fake.listSpacesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
What
----

We'd like to label our metrics with the owner. Adding it into the
Database when the orgs are being gathered is the easiest option at the
moment...

This can only be accommodated with the V3 API, so making a custom call.

The client has been regenerated with counterfeiter.

```
counterfeiter -o fakes/fake_cf_data_client.go cfstore/cfstore_client.go CFDataClient
```

How to review
-----

- Code review
- Run tests
- Run the app in safe environment and expect it to fill in the data properly
- See if my SQL changes are good or over thought...
