### PR TITLE
Remove NOT NULL requirement

### DIFF
--- a/eventstore/sql/2021-05-06-alter_orgs.sql
+++ b/eventstore/sql/2021-05-06-alter_orgs.sql
@@ -1,1 +1,1 @@
-alter table orgs add column if not exists owner text not null check (length(name)>0);
+alter table orgs add column if not exists owner text check (length(owner)>0);

--- a/eventstore/sql/create_orgs.sql
+++ b/eventstore/sql/create_orgs.sql
@@ -2,7 +2,7 @@ create table if not exists orgs (
 	guid uuid not null,
 	valid_from timestamptz not null,
 	name text not null check (length(name)>0),
-	owner text not null check (length(name)>0),
+	owner text check (length(owner)>0),
 	created_at timestamptz not null,
 	updated_at timestamptz not null,
 	quota_definition_guid uuid,


### PR DESCRIPTION
What
----

Because the previous data has already been there... The values are not
populated and throwing an error whilst running migration.

Also correcting the check function to check correct column...
