### PR TITLE
#177457361 Set a default value for `owner` in `orgs` table

### DIFF
--- a/eventstore/sql/2021-05-06-alter_orgs.sql
+++ b/eventstore/sql/2021-05-06-alter_orgs.sql
@@ -1,1 +1,1 @@
-alter table orgs add column if not exists owner text check (length(owner)>0);
+alter table orgs add column if not exists owner text not null default 'Owner not set';

--- a/eventstore/sql/create_orgs.sql
+++ b/eventstore/sql/create_orgs.sql
@@ -2,7 +2,7 @@ create table if not exists orgs (
 	guid uuid not null,
 	valid_from timestamptz not null,
 	name text not null check (length(name)>0),
-	owner text check (length(owner)>0),
+	owner text not null default 'Owner not set',
 	created_at timestamptz not null,
 	updated_at timestamptz not null,
 	quota_definition_guid uuid,


### PR DESCRIPTION
# What
Not all orgs in our production CF database seem to have the owner metadata set (e.g. tests). This breaks the (re-)generation of the orgs table in the `billing-db`.

Setting a default `Owner not set` value of `owner` in the `orgs` table so that the generation of the table does not fail.

How to review
-----
- Code review
- Check SQL to be working in a dev env (or staging for that matter). The `owner` column may need to be dropped for the logic to work properly.

Who can review
-----

not @schmie 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
