### PR TITLE
Recalculate VAT as percentage of net amount, add columns to resources

### DIFF
--- a/billing-db/sprocs/calculate_bill.sql
+++ b/billing-db/sprocs/calculate_bill.sql
@@ -5,7 +5,6 @@ CREATE TEMPORARY TABLE billable_resources
 (
     valid_from TIMESTAMP NOT NULL,
     valid_to TIMESTAMP NOT NULL,
-    time_in_seconds INT NULL,
     resource_guid UUID NULL,
     resource_type TEXT NULL,
     resource_name TEXT NULL,
@@ -14,7 +13,10 @@ CREATE TEMPORARY TABLE billable_resources
     space_guid UUID NULL,
     space_name TEXT NULL,
     plan_name TEXT NULL,
-    plan_guid UUID NULL -- Later on this field may not be needed
+    plan_guid UUID NULL,
+    storage_in_mb NUMERIC NULL,
+    memory_in_mb NUMERIC NULL,
+    number_of_nodes INT NULL
 );
 
 -- The billable_by_component table needs creating before running this stored function. This is so we can preserve the contents of this table for audit/debug purposes.
@@ -32,7 +34,7 @@ CREATE TEMPORARY TABLE billable_by_component
     space_guid UUID NULL,
     space_name TEXT NULL,
     plan_name TEXT NULL,
-    plan_guid UUID NULL, -- Later on this field may not be needed
+    plan_guid UUID NULL,
     component_name TEXT NULL,
 
     storage_in_mb NUMERIC NULL,
@@ -62,9 +64,12 @@ RETURNS TABLE
 (
     org_name TEXT,
     org_guid UUID,
+    plan_guid UUID,
     plan_name TEXT,
     space_name TEXT,
+    resource_type TEXT,
     resource_name TEXT,
+    component_name TEXT,
     charge_usd_exc_vat DECIMAL,
     charge_gbp_exc_vat DECIMAL,
     charge_gbp_inc_vat DECIMAL
@@ -141,9 +146,9 @@ BEGIN
             br.plan_guid,
             c.component_name,
             EXTRACT(EPOCH FROM (br.valid_to - c.valid_from)), -- time_in_seconds
-            c.storage_in_mb,
-            c.memory_in_mb,
-            c.number_of_nodes,
+            br.storage_in_mb,
+            br.memory_in_mb,
+            br.number_of_nodes,
             c.aws_price,
             c.generic_formula,
             c.vat_code,
@@ -173,9 +178,9 @@ BEGIN
             br.plan_guid,
             c.component_name,
             EXTRACT(EPOCH FROM (br.valid_to - br.valid_from)), -- time_in_seconds
-            c.storage_in_mb,
-            c.memory_in_mb,
-            c.number_of_nodes,
+            br.storage_in_mb,
+            br.memory_in_mb,
+            br.number_of_nodes,
             c.aws_price,
             c.generic_formula,
             c.vat_code,
@@ -205,9 +210,9 @@ BEGIN
             br.plan_guid,
             c.component_name,
             EXTRACT(EPOCH FROM (c.valid_to - br.valid_from)), -- time_in_seconds
-            c.storage_in_mb,
-            c.memory_in_mb,
-            c.number_of_nodes,
+            br.storage_in_mb,
+            br.memory_in_mb,
+            br.number_of_nodes,
             c.aws_price,
             c.generic_formula,
             c.vat_code,
@@ -236,9 +241,9 @@ BEGIN
             br.plan_guid,
             c.component_name,
             EXTRACT(EPOCH FROM (c.valid_to - c.valid_from)), -- time_in_seconds
-            c.storage_in_mb,
-            c.memory_in_mb,
-            c.number_of_nodes,
+            br.storage_in_mb,
+            br.memory_in_mb,
+            br.number_of_nodes,
             c.aws_price,
             c.generic_formula,
             c.vat_code,
@@ -541,9 +546,8 @@ BEGIN
             br.charge_usd_exc_vat,
             br.charge_gbp_exc_vat,
             -- The calculation in the following line is: charge including VAT * (proportion of time this VAT rate is active versus time we're billing for)
-            (br.charge_gbp_exc_vat/(1 - v.vat_rate)) * ((EXTRACT(EPOCH FROM (br.valid_to - v.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
-            -- charge_gbp_exc_vat is the charge excluding VAT. The charge including VAT is: charge excluding VAT/(1 - VAT rate), because 
-            --     charge inc. VAT - (charge inc. VAT * VAT rate) = charge exc. VAT
+            (br.charge_gbp_exc_vat + (br.charge_gbp_exc_vat * v.vat_rate)) * ((EXTRACT(EPOCH FROM (br.valid_to - v.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
+            -- The charge including VAT is: charge_gbp_exc_vat (charge excluding VAT) + VAT charge
     FROM billable_by_component_fx br,
          vat_rates_new v
     WHERE br.valid_from < v.valid_from
@@ -578,9 +582,8 @@ BEGIN
             br.charge_usd_exc_vat,
             br.charge_gbp_exc_vat,
             -- The calculation in the following line is: charge including VAT * (proportion of time this VAT rate is active versus time we're billing for)
-            (br.charge_gbp_exc_vat/(1 - v.vat_rate)) * ((EXTRACT(EPOCH FROM (br.valid_to - br.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
-            -- charge_gbp_exc_vat is the charge excluding VAT. The charge including VAT is: charge excluding VAT/(1 - VAT rate), because 
-            --     charge inc. VAT - (charge inc. VAT * VAT rate) = charge exc. VAT
+            (br.charge_gbp_exc_vat + (br.charge_gbp_exc_vat * v.vat_rate)) * ((EXTRACT(EPOCH FROM (br.valid_to - br.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
+            -- The charge including VAT is: charge_gbp_exc_vat (charge excluding VAT) + VAT charge
     FROM billable_by_component_fx br,
          vat_rates_new v
     WHERE br.valid_from >= v.valid_from
@@ -615,9 +618,8 @@ BEGIN
             br.charge_usd_exc_vat,
             br.charge_gbp_exc_vat,
             -- The calculation in the following line is: charge including VAT * (proportion of time this VAT rate is active versus time we're billing for)
-            (br.charge_gbp_exc_vat/(1 - v.vat_rate)) * ((EXTRACT(EPOCH FROM (v.valid_to - br.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
-            -- charge_gbp_exc_vat is the charge excluding VAT. The charge including VAT is: charge excluding VAT/(1 - VAT rate), because 
-            --     charge inc. VAT - (charge inc. VAT * VAT rate) = charge exc. VAT
+            (br.charge_gbp_exc_vat + (br.charge_gbp_exc_vat * v.vat_rate)) * ((EXTRACT(EPOCH FROM (v.valid_to - br.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
+            -- The charge including VAT is: charge_gbp_exc_vat (charge excluding VAT) + VAT charge
     FROM billable_by_component_fx br,
          vat_rates_new v
     WHERE br.valid_from > v.valid_from
@@ -651,9 +653,8 @@ BEGIN
             br.charge_usd_exc_vat,
             br.charge_gbp_exc_vat,
             -- The calculation in the following line is: charge including VAT * (proportion of time this VAT rate is active versus time we're billing for)
-            (br.charge_gbp_exc_vat/(1 - v.vat_rate)) * ((EXTRACT(EPOCH FROM (v.valid_to - v.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
-            -- charge_gbp_exc_vat is the charge excluding VAT. The charge including VAT is: charge excluding VAT/(1 - VAT rate), because 
-            --     charge inc. VAT - (charge inc. VAT * VAT rate) = charge exc. VAT
+            (br.charge_gbp_exc_vat + (br.charge_gbp_exc_vat * v.vat_rate)) * ((EXTRACT(EPOCH FROM (v.valid_to - v.valid_from)))::NUMERIC/time_in_seconds) -- charge_inc_vat
+            -- The charge including VAT is: charge_gbp_exc_vat (charge excluding VAT) + VAT charge
     FROM billable_by_component_fx br,
          vat_rates_new v
     WHERE br.valid_from < v.valid_from
@@ -663,17 +664,23 @@ BEGIN
     RETURN QUERY
     SELECT bac.org_name,
            bac.org_guid,
+           bac.plan_guid,
            bac.plan_name,
            bac.space_name,
+           bac.resource_type,
            bac.resource_name,
+           bac.component_name,
            SUM(bac.charge_usd_exc_vat) AS charge_usd_exc_vat,
            SUM(bac.charge_gbp_exc_vat) AS charge_gbp_exc_vat,
            SUM(bac.charge_gbp_inc_vat) AS charge_gbp_inc_vat
     FROM billable_by_component bac
     GROUP BY bac.org_name, 
-             bac.org_guid, 
+             bac.org_guid,
+             bac.plan_guid,
              bac.plan_name,
              bac.space_name,
-             bac.resource_name;
+             bac.resource_type,
+             bac.resource_name,
+             bac.component_name;
 END
 $$;

--- a/billing-db/sprocs/get_tenant_bill.sql
+++ b/billing-db/sprocs/get_tenant_bill.sql
@@ -13,7 +13,10 @@ CREATE TEMPORARY TABLE billable_resources
     space_guid UUID NULL,
     space_name TEXT NULL,
     plan_name TEXT NULL,
-    plan_guid UUID NULL -- Later on this field may not be needed
+    plan_guid UUID NULL,
+    storage_in_mb NUMERIC NULL,
+    memory_in_mb NUMERIC NULL,
+    number_of_nodes INT NULL
 );
 
 -- The billable_by_component table needs creating before running this stored function. This is so we can preserve the contents of this table for audit/debug purposes.
@@ -21,8 +24,8 @@ CREATE TEMPORARY TABLE billable_by_component
 (
     valid_from TIMESTAMP NOT NULL,
     valid_to TIMESTAMP NOT NULL,
-    -- valid_from_month TODO Add - useful if we're calculating bills for more than one month
-    -- valid_to_month TODO Add - useful if we're calculating bills for more than one month
+    -- valid_from_month - useful if we're calculating bills for more than one month
+    -- valid_to_month - useful if we're calculating bills for more than one month
     resource_guid UUID NULL,
     resource_type TEXT NULL,
     resource_name TEXT NULL,
@@ -31,8 +34,8 @@ CREATE TEMPORARY TABLE billable_by_component
     space_guid UUID NULL,
     space_name TEXT NULL,
     plan_name TEXT NULL,
-    plan_guid UUID NULL, -- Later on this field may not be needed
-    component_name TEXT NOT NULL,
+    plan_guid UUID NULL,
+    component_name TEXT NULL,
 
     storage_in_mb NUMERIC NULL,
     memory_in_mb NUMERIC NULL,
@@ -62,9 +65,12 @@ RETURNS TABLE
 (
     org_name TEXT,
     org_guid UUID,
+    plan_guid UUID,
     plan_name TEXT,
     space_name TEXT,
+    resource_type TEXT,
     resource_name TEXT,
+    component_name TEXT,
     charge_usd_exc_vat DECIMAL,
     charge_gbp_exc_vat DECIMAL,
     charge_gbp_inc_vat DECIMAL
@@ -85,7 +91,10 @@ BEGIN
         space_guid,
         space_name,
         plan_name,
-        plan_guid
+        plan_guid,
+        storage_in_mb,
+        memory_in_mb,
+        number_of_nodes
     )
     -- _from_date, _to_date:                  |---------------------------|
     -- Resource present:            |-----------------|
@@ -99,7 +108,10 @@ BEGIN
             r.space_guid,
             r.space_name,
             r.plan_name,
-            r.plan_guid
+            r.plan_guid,
+            r.storage_in_mb,
+            r.memory_in_mb,
+            r.number_of_nodes
     FROM  resources r
     WHERE r.org_name = _org_name
     AND   r.valid_from < _from_date
@@ -119,7 +131,10 @@ BEGIN
             r.space_guid,
             r.space_name,
             r.plan_name,
-            r.plan_guid
+            r.plan_guid,
+            r.storage_in_mb,
+            r.memory_in_mb,
+            r.number_of_nodes
     FROM  resources r
     WHERE r.org_name = _org_name
     AND   r.valid_from >= _from_date
@@ -139,7 +154,10 @@ BEGIN
             r.space_guid,
             r.space_name,
             r.plan_name,
-            r.plan_guid
+            r.plan_guid,
+            r.storage_in_mb,
+            r.memory_in_mb,
+            r.number_of_nodes
     FROM  resources r
     WHERE r.org_name = _org_name
     AND   r.valid_from > _from_date
@@ -158,7 +176,10 @@ BEGIN
             r.space_guid,
             r.space_name,
             r.plan_name,
-            r.plan_guid
+            r.plan_guid,
+            r.storage_in_mb,
+            r.memory_in_mb,
+            r.number_of_nodes
     FROM  resources r
     WHERE r.org_name = _org_name
     AND   r.valid_from < _from_date

--- a/billing-db/tables/currency_exchange_rates.sql
+++ b/billing-db/tables/currency_exchange_rates.sql
@@ -7,5 +7,6 @@ CREATE TABLE IF NOT EXISTS currency_exchange_rates
     rate NUMERIC NOT NULL,
 
     PRIMARY KEY (from_ccy, to_ccy, valid_to),
-    CONSTRAINT rate_must_be_greater_than_zero CHECK (rate > 0)
+    CONSTRAINT rate_must_be_greater_than_zero CHECK (rate > 0),
+    CONSTRAINT rate_one_when_same_currency CHECK ((from_ccy != to_ccy) OR (from_ccy = to_ccy AND rate = 1))
 );

--- a/billing-db/tables/resources.sql
+++ b/billing-db/tables/resources.sql
@@ -11,6 +11,9 @@ CREATE TABLE IF NOT EXISTS resources
 	space_name TEXT NOT NULL,
 	plan_name TEXT NOT NULL,
 	plan_guid UUID NOT NULL,
+	storage_in_mb NUMERIC NULL,
+	memory_in_mb NUMERIC NULL,
+	number_of_nodes INT NULL,
 	-- source VARCHAR NULL, -- This can be added later if needed. Source system from which this was last updated from, e.g. Cloudfoundry
 	cf_event_guid UUID NULL, -- Cloudfoundry event_guid that was last used to update this row. Not used by code that calculates tenant bills (e.g. calculate_bill())
 	last_updated TIMESTAMPTZ NOT NULL -- When this row was last updated


### PR DESCRIPTION
What
----

Changes in calculate_bill to recalculate VAT as a percentage of net amount not gross amount.

Return results from calculate_bill() in more granular format; this will be useful later.

Adding 3 columns to resource table and changes needed in calculate_bill and get_tenant_bill.

Tidying up get_tenant_bill/calculate_bill

Addition of constraint to facilitate currency conversion in calculate_bill()

How to review
-----

Check you're happy with the code changes. The main change is the recalculation of VAT. Changes have been fully tested.

Who can review
-----

Not @poveyd 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
