### PR TITLE
Round charges to 3 decimal places

### DIFF
--- a/billing-db/sprocs/calculate_bill.sql
+++ b/billing-db/sprocs/calculate_bill.sql
@@ -670,9 +670,9 @@ BEGIN
            bac.resource_type,
            bac.resource_name,
            bac.component_name,
-           SUM(bac.charge_usd_exc_vat) AS charge_usd_exc_vat,
-           SUM(bac.charge_gbp_exc_vat) AS charge_gbp_exc_vat,
-           SUM(bac.charge_gbp_inc_vat) AS charge_gbp_inc_vat
+           ROUND(SUM(bac.charge_usd_exc_vat), 3) AS charge_usd_exc_vat,
+           ROUND(SUM(bac.charge_gbp_exc_vat), 3) AS charge_gbp_exc_vat,
+           ROUND(SUM(bac.charge_gbp_inc_vat), 3) AS charge_gbp_inc_vat
     FROM billable_by_component bac
     GROUP BY bac.org_name, 
              bac.org_guid, 


### PR DESCRIPTION
What
----

I have rounded the charges produced by the `calculate_bill()` stored function to 3 decimal places. Previously, they were not rounded.

`calculate_bill()` is the stored function that calculates bills for tenants, broken down by org, space, resource, etc. in the new version of Paas billing.

How to review
-----

Please make sure you are happy with the rounding to 3 decimal places. We need tenant bills rounded to 2 decimal places but an extra decimal place has been included in case of any possible future Postgres rounding/floating point arithmetic issues.

Should you want to test the change, the stored function can be loaded into a test database that is a snapshot of production billing database. In a psql session against this database, create the temporary tables (whose definitions are found at the top of https://github.com/alphagov/paas-billing/blob/round_results/billing-db/sprocs/calculate_bill.sql) then run the following:

```
SELECT * FROM get_tenant_bill('govuk-pay', '2021-12-01', '2021-01-01');
```


Who can review
-----

Not poveyd

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
