### PR TITLE
Ensure the _from_date parameter is earlier than the _to_date when calling get_tenant_bill.

### DIFF
--- a/billing-db/sprocs/get_tenant_bill.sql
+++ b/billing-db/sprocs/get_tenant_bill.sql
@@ -79,6 +79,10 @@ LANGUAGE plpgsql AS $$
 BEGIN
     TRUNCATE TABLE billable_resources;
 
+    IF _from_date >= _to_date THEN
+        RAISE EXCEPTION 'The from_date ("%") passed into get_tenant_bill needs to be before the to_date ("%").', _from_date, _to_date;
+    END IF;
+
     INSERT INTO billable_resources
     (
         valid_from,
@@ -183,6 +187,7 @@ BEGIN
     FROM  resources r
     WHERE r.org_name = _org_name
     AND   r.valid_from < _from_date
+    AND   r.valid_to > _from_date
     AND   r.valid_to > _to_date;
 
     RETURN QUERY


### PR DESCRIPTION
What
----

Ensure the _from_date parameter is earlier than the _to_date when calling get_tenant_bill. The extra where clause criterion also prevents incorrect billing reports being generated if the first check is removed from the code in the future and if the _from_date is later than the _to_date.

This is to prevent any future problems (either from uses adding in invalid dates in the website or coding problems).

How to review
-----

Load the code into a test copy of production database. Run the existing get_tenant_bill code then run the new version of get_tenant_bill, both using same input parameters and valid _from_date and to_dates. The results will be the same. Then run the new code, setting the _from_date to be the same or after the _to_date and the get_tenant_bill stored function should fail with an informative error message.

Who can review
-----

Not poveyd

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
