### PR TITLE
[#179252161] bump golang to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-billing
 
-go 1.15
+go 1.16
 
 require (
 	code.cloudfoundry.org/lager v0.0.0-20180322215153-25ee72f227fe

--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -8,6 +8,6 @@ applications:
    health-check-type: http
    stack: cflinuxfs3
    env:
-     GOVERSION: go1.15
+     GOVERSION: go1.16
      GOPACKAGENAME: github.com/alphagov/paas-billing
    command: ./bin/paas-billing api

--- a/manifest-collector.yml
+++ b/manifest-collector.yml
@@ -9,6 +9,6 @@ applications:
    health-check-type: process
    no-route: true
    env:
-     GOVERSION: go1.15
+     GOVERSION: go1.16
      GOPACKAGENAME: github.com/alphagov/paas-billing
    command: ./bin/paas-billing collector


### PR DESCRIPTION
## What

Bump the required version of golang in the module and cf manifest to 1.16, because we're about to roll out a buildpack which removes 1.15.

## How to review

Set a dev pipeline's `paas-billing` resource's `branch` to this one?

## Who can review

Human engineers.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
