### PR TITLE
Change generateMissingPlans to not look for Epoch

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -681,7 +681,7 @@ func (s *EventStore) generateMissingPlans(tx *sql.Tx) error {
 				select distinct plan_guid
 				from pricing_plans pp
 				where pp.plan_guid = events.plan_guid
-				and valid_from = 'epoch'::timestamptz
+				and valid_from < lower(events.duration)
 			)
 		)
 		returning plan_guid, name


### PR DESCRIPTION


What
----
It is no longer the case that pricing plans have to cover the whole epoch, this was causing problems with the pricing calculator.

Instead make sure that there is a pricing plan that exists before the event in question.



How to review
-----

Deploy to a dev environment and make sure that 'app app' events are not created and that the billing collector can run.

Who can review
-----
Not @whpearson 


Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
