### PR TITLE
Stop looking for pricing plan components from the beginning of time

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -720,7 +720,7 @@ func (s *EventStore) generateMissingPlans(tx *sql.Tx) error {
 				select distinct plan_guid
 				from pricing_plan_components ppc
 				where ppc.plan_guid = events.plan_guid
-				and valid_from = 'epoch'::timestamptz
+				and valid_from < lower(events.duration)
 			)
 		)`,
 	); err != nil {


### PR DESCRIPTION

What
----
We now have components that start after the beginning of time EPOCH.

This however confuses the generateMissingPlans function as it still
looks for things that start at EPOCH. So it the tries to
generate new pricing components, with epoch as the starting time and
fails as it does not match the pricing plan (the logic we fixed in this
commit https://github.com/alphagov/paas-billing/pull/133/commits).

This fixes the logic in the same way to make sure we generate a pricing plan
component only if we need one for the current event, that is there is
not a component valid before the start of the event.


How to review
-----
Code review

Who can review
-----

Not @whpearson 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
