### PR TITLE
Update timeouts and frequency to avoid locking problems

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -25,7 +25,7 @@ const (
 	TaskPlanGUID          = "ebfa9453-ef66-450c-8c37-d53dfd931038"
 	StagingPlanGUID       = "9d071c77-7a68-4346-9981-e8dafac95b6f"
 	DefaultInitTimeout    = 25 * time.Minute
-	DefaultRefreshTimeout = 180 * time.Minute
+	DefaultRefreshTimeout = 450 * time.Minute
 	DefaultStoreTimeout   = 45 * time.Second
 	DefaultQueryTimeout   = 45 * time.Second
 )

--- a/main_config.go
+++ b/main_config.go
@@ -98,7 +98,7 @@ func NewConfigFromEnv() (cfg Config, err error) {
 			FetchLimit:   getEnvWithDefaultInt("CF_FETCH_LIMIT", 50),
 		},
 		Processor: ProcessorConfig{
-			Schedule: getEnvWithDefaultDuration("PROCESSOR_SCHEDULE", 240*time.Minute),
+			Schedule: getEnvWithDefaultDuration("PROCESSOR_SCHEDULE", 480*time.Minute),
 		},
 		ServerPort: getEnvWithDefaultInt("PORT", 8881),
 	}

--- a/main_config_test.go
+++ b/main_config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Config", func() {
 		Expect(cfg.Collector.MinWaitTime).To(Equal(3 * time.Second))
 		Expect(cfg.CFFetcher.RecordMinAge).To(Equal(10 * time.Minute))
 		Expect(cfg.CFFetcher.FetchLimit).To(Equal(50))
-		Expect(cfg.Processor.Schedule).To(Equal(240 * time.Minute))
+		Expect(cfg.Processor.Schedule).To(Equal(480 * time.Minute))
 		Expect(cfg.ServerPort).To(Equal(8881))
 	})
 


### PR DESCRIPTION


What
----

We are seeing locking problems during update resources. This might be
due to trying to run multiple updates at once.

Make refresh happen every 8 hours and the time out be 7 hours and 30
mins

How to review
-----

Code review

Who can review
-----

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
