### PR TITLE
Add opensearch to usage and adoption csv

### DIFF
--- a/scripts/ireland-usage-and-adoption-generate-csv.sql
+++ b/scripts/ireland-usage-and-adoption-generate-csv.sql
@@ -44,6 +44,7 @@ org_bills_by_plan_by_month AS
               WHEN plan_name ~ 'redis.*' THEN 'redis'
               WHEN plan_name ~ 'aws-s3.*' THEN 's3'
               WHEN plan_name ~ 'aws-sqs-queue.*' THEN 'sqs'
+              WHEN plan_name ~ 'opensearch.*' THEN 'opensearch'
               ELSE plan_name::text
           END AS service,
           sum(cost) AS total_cost
@@ -72,11 +73,13 @@ SELECT mon,
        COALESCE(service_costs->>'s3', '0') AS s3,
        COALESCE(service_costs->>'influxdb', '0') AS influxdb,
        COALESCE(service_costs->>'sqs', '0') AS sqs,
+       COALESCE(service_costs->>'opensearch', '0') AS opensearch,
 
        COALESCE(service_costs->>'compute', '0')::numeric
        + COALESCE(service_costs->>'postgres', '0')::numeric
        + COALESCE(service_costs->>'mysql', '0')::numeric
        + COALESCE(service_costs->>'elasticsearch', '0')::numeric
+       + COALESCE(service_costs->>'opensearch', '0')::numeric
        + COALESCE(service_costs->>'redis', '0')::numeric
        + COALESCE(service_costs->>'s3', '0')::numeric
        + COALESCE(service_costs->>'influxdb', '0')::numeric

--- a/scripts/london-usage-and-adoption-generate-csv.sql
+++ b/scripts/london-usage-and-adoption-generate-csv.sql
@@ -44,6 +44,7 @@ org_bills_by_plan_by_month AS
               WHEN plan_name ~ 'redis.*' THEN 'redis'
               WHEN plan_name ~ 'aws-s3.*' THEN 's3'
               WHEN plan_name ~ 'aws-sqs-queue.*' THEN 'sqs'
+              WHEN plan_name ~ 'opensearch.*' THEN 'opensearch'
               ELSE plan_name::text
           END AS service,
           sum(cost) AS total_cost
@@ -72,6 +73,7 @@ SELECT mon,
        COALESCE(service_costs->>'s3', '0') AS s3,
        COALESCE(service_costs->>'influxdb', '0') AS influxdb,
        COALESCE(service_costs->>'sqs', '0') AS sqs,
+       COALESCE(service_costs->>'opensearch', '0') AS opensearch,
 
        COALESCE(service_costs->>'compute', '0')::numeric
        + COALESCE(service_costs->>'postgres', '0')::numeric
@@ -81,6 +83,7 @@ SELECT mon,
        + COALESCE(service_costs->>'s3', '0')::numeric
        + COALESCE(service_costs->>'influxdb', '0')::numeric
        + COALESCE(service_costs->>'sqs', '0')::numeric
+       + COALESCE(service_costs->>'opensearch', '0')::numeric
        AS total
 FROM aggregated_org_bills_by_plan_by_month JOIN distinct_orgs_first_seen
 ON aggregated_org_bills_by_plan_by_month.org_guid = distinct_orgs_first_seen.org_guid


### PR DESCRIPTION

What
----

For both regions

We need to alter the sql to correctly annotate the data for opensearch.

How to review
-----
Login to london as an operator
Run the tests sql scripts against an environment by creating a conduit to the billing-db
```
cf conduit billing-db -- psql   
```
Then run the psql commands in the conduit
```
"\a" to ensure your output is unaligned
"\f ," to output the results separated by commas
"\o /tmp/results-london.csv" to save the output in a CSV
"\i scripts/london-usage-and-adoption-generate-csv.sql" to run this query
```
Validate that the output is sensible in /tmp/results-london.csv


Who can review
-----

Not @whpearson 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
