### PR TITLE
Update billing app manifests downgrade go to 1.17

### DIFF
--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -8,6 +8,6 @@ applications:
    health-check-type: http
    stack: cflinuxfs3
    env:
-     GOVERSION: go1.18
+     GOVERSION: go1.17
      GOPACKAGENAME: github.com/alphagov/paas-billing
    command: ./bin/paas-billing api

--- a/manifest-collector.yml
+++ b/manifest-collector.yml
@@ -9,6 +9,6 @@ applications:
    health-check-type: process
    no-route: true
    env:
-     GOVERSION: go1.18
+     GOVERSION: go1.17
      GOPACKAGENAME: github.com/alphagov/paas-billing
    command: ./bin/paas-billing collector


### PR DESCRIPTION


What
----
We need to downgrade to 1.17 in order to create overlap between buildpacks

How to review
-----

- Check tests pass.

Who can review
-----
not @schmie 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
