### PR TITLE
Rename acceptance tests to fix smoke tests

### DIFF
--- a/acceptance_tests/acceptance_test.go
+++ b/acceptance_tests/acceptance_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("Acceptance", func() {
-	It("can get pricing plans", func(){
+	It("can get pricing plans from api", func() {
 		billingAPIURL, err := url.Parse(TestConfig.BillingAPIURL)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -28,7 +28,7 @@ var _ = Describe("Acceptance", func() {
 		Expect(resp.StatusCode).To(Equal(200))
 	})
 
-	It("can get billable events", func(){
+	It("can get billable events from api", func() {
 		billingAPIURL, err := url.Parse(TestConfig.BillingAPIURL)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
What
----

There seems to have been a regression of the acceptance test names that were renamed to allow filtering of api tests for our smoke tests.

How to review
-----

- Code review
- Optionally check smoke tests are not skipped in a dev env

Who can review
-----

no @schmie 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
