### PR TITLE
We need to start the health server before initialising the collector

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,9 @@ func Main(ctx context.Context, logger lager.Logger) error {
 }
 
 func startCollector(app *App, cfg Config) error {
+	if err := app.StartHealthServer(); err != nil {
+		return err
+	}
 	if err := app.Init(); err != nil {
 		return err
 	}
@@ -53,9 +56,6 @@ func startCollector(app *App, cfg Config) error {
 		return err
 	}
 	if err := app.StartHistoricDataCollector(); err != nil {
-		return err
-	}
-	if err := app.StartHealthServer(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
What
----

We need to start the health server before initialising the collector.

Environments with a large database have a slow start up time. We need to start the health probe earlier.

How to review
-----

Deployment can be found [here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-billing/builds/28)

Who can review
-----

One of the old timers

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
