### PR TITLE
eventstore create_events: use custom aggregators to significantly accelerate

### DIFF
--- a/eventstore/migrations/0120_last_agg.up.sql
+++ b/eventstore/migrations/0120_last_agg.up.sql
@@ -1,0 +1,22 @@
+-- **do not alter - add new migrations instead**
+
+BEGIN;
+
+
+--
+-- add basic last_agg aggregation function, which simply returns the value most
+-- recently presented to it. powerful when used with aggregation FILTER clause.
+--
+
+
+CREATE FUNCTION last_agg_sfunc (state anyelement, newval anyelement) RETURNS anyelement AS $$
+	SELECT newval;
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE last_agg (anyelement) (
+	SFUNC = last_agg_sfunc
+	, STYPE = anyelement
+);
+
+
+COMMIT;

--- a/eventstore/migrations/0130_anydistinct.up.sql
+++ b/eventstore/migrations/0130_anydistinct.up.sql
@@ -1,0 +1,56 @@
+-- **do not alter - add new migrations instead**
+
+BEGIN;
+
+
+--
+-- add aggregation function anydistinct() for text and uuid types, which
+-- compares successive values for distinctness and returns true if any
+-- are found to be. assuming the type has transitive equality, a false
+-- value therefore implies all values are equal (or null).
+--
+-- postgresql polymorphism isn't quite powerful enough to avoid having
+-- to declare this per-type.
+--
+
+CREATE TYPE anydistinct_stype_uuid AS (prior boolean, prev uuid);
+
+CREATE FUNCTION anydistinct_sfunc_uuid (state anydistinct_stype_uuid, newval uuid) RETURNS anydistinct_stype_uuid AS $$
+	-- prior being null indicates this being the first element, which is never considered distinct
+	SELECT
+		state.prior IS NOT NULL AND (state.prior OR state.prev IS DISTINCT FROM newval) AS prior,
+		newval AS prev;
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION anydistinct_finalfunc_uuid (state anydistinct_stype_uuid) RETURNS boolean AS $$
+	SELECT state.prior;
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE anydistinct (uuid) (
+	SFUNC = anydistinct_sfunc_uuid
+	, STYPE = anydistinct_stype_uuid
+	, FINALFUNC = anydistinct_finalfunc_uuid
+);
+
+
+CREATE TYPE anydistinct_stype_text AS (prior boolean, prev text);
+
+CREATE FUNCTION anydistinct_sfunc_text (state anydistinct_stype_text, newval text) RETURNS anydistinct_stype_text AS $$
+	-- prior being null indicates this being the first element, which is never considered distinct
+	SELECT
+		state.prior IS NOT NULL AND (state.prior OR state.prev IS DISTINCT FROM newval) AS prior,
+		newval AS prev;
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION anydistinct_finalfunc_text (state anydistinct_stype_text) RETURNS boolean AS $$
+	SELECT state.prior;
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE anydistinct (text) (
+	SFUNC = anydistinct_sfunc_text
+	, STYPE = anydistinct_stype_text
+	, FINALFUNC = anydistinct_finalfunc_text
+);
+
+
+COMMIT;

--- a/eventstore/sql/create_billable_event_components.sql
+++ b/eventstore/sql/create_billable_event_components.sql
@@ -114,3 +114,5 @@ ALTER INDEX billable_event_components_temp_pkey RENAME TO billable_event_compone
 ALTER INDEX billable_event_components_temp_org_idx RENAME TO billable_event_components_org_idx;
 ALTER INDEX billable_event_components_temp_space_idx RENAME TO billable_event_components_space_idx;
 ALTER INDEX billable_event_components_temp_duration_idx RENAME TO billable_event_components_duration_idx;
+
+ANALYZE billable_event_components;

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -377,3 +377,5 @@ ALTER INDEX events_space_temp_idx RENAME TO events_space_idx;
 ALTER INDEX events_resource_temp_idx RENAME TO events_resource_idx;
 ALTER INDEX events_duration_temp_idx RENAME TO events_duration_idx;
 ALTER INDEX events_plan_temp_idx RENAME TO events_plan_idx;
+
+ANALYZE events;

--- a/eventstore/sql/create_events.sql
+++ b/eventstore/sql/create_events.sql
@@ -195,8 +195,6 @@ INSERT INTO events_temp with
 				order by created_at, event_sequence
 				rows between unbounded preceding and current row
 			)
-		order by
-			created_at, event_sequence
 	),
 	event_ranges as (
 		select
@@ -363,8 +361,6 @@ INSERT INTO events_temp with
 	where
 		state = 'STARTED'
 		and not isempty(duration)
-	order by
-		event_sequence, event_guid
 ;
 
 CREATE INDEX events_org_temp_idx ON events_temp (org_guid);

--- a/eventstore/sql/create_view_billable_event_components_by_day.sql
+++ b/eventstore/sql/create_view_billable_event_components_by_day.sql
@@ -141,3 +141,4 @@ CREATE INDEX IF NOT EXISTS
 
 REFRESH MATERIALIZED VIEW billable_event_components_by_day;
 
+ANALYZE billable_event_components_by_day;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183803351

What
----

Broadly, this introduces two new custom aggregators and uses them to significantly reduce the query time for the `create_events.sql` operation. `last_agg` can be used to replace some array-based hacks used for populating missing values from previous events in window functions. This reduces the query time from ~12h to ~7m.

`anydistinct` is used to remove redundant rows from the `valid_service_plans`, `valid_services`, `valid_orgs` and `valid_spaces` common table expressions which we later outer-join against. This halves the remaining query time to ~3 minutes.

The entire "refresh" procedure still takes ~30mins but this is now almost entirely the other queries performed as part of that, which I haven't looked at (but could do if needs be).

Please see the individual commits for more detail on each change.

How to review
-----

Look at prod-lon's "billing-experimental" deployment, which should be operating correctly, with approximately 30 min refresh operations.

I have verified that this query produces identical results to the previous one when run against production data. I can show this upon request.

Who can review
-----

Perhaps people want to wait until after the explainer session before reviewing this :shrug: 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
