### PR TITLE
collector initialization: move initial `regenerateEvents()` call to start of event processor loop

### DIFF
--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -125,9 +125,6 @@ func (s *EventStore) Init() error {
 		return err
 	}
 
-	if err := s.regenerateEvents(); err != nil {
-		return err
-	}
 	s.logger.Info("initialized")
 	return nil
 }

--- a/main_app.go
+++ b/main_app.go
@@ -133,23 +133,21 @@ func runRefreshAndConsolidateLoop(ctx context.Context, logger lager.Logger, sche
 	logger.Info("started")
 	defer logger.Info("stopping")
 	for {
+		logger.Info("processing")
+		if err := store.Refresh(); err != nil {
+			logger.Error("refresh-error", err)
+		} else if err := store.ConsolidateAll(); err != nil {
+			logger.Error("consolidate-error", err)
+		} else {
+			logger.Info("processed", lager.Data{
+				"next_processing_in": schedule.String(),
+			})
+		}
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(schedule):
-			logger.Info("processing")
-			if err := store.Refresh(); err != nil {
-				logger.Error("refresh-error", err)
-				continue
-			}
-			if err := store.ConsolidateAll(); err != nil {
-				logger.Error("consolidate-error", err)
-				continue
-			}
 		}
-		logger.Info("processed", lager.Data{
-			"next_processing_in": schedule.String(),
-		})
 	}
 }
 

--- a/main_app_collector_test.go
+++ b/main_app_collector_test.go
@@ -138,6 +138,28 @@ var _ = Describe("runRefreshAndConsolidateLoop", func() {
 		}).Should(BeNumerically(">=", 1))
 	})
 
+	It("should call Refresh and Consolidate once initially before 'Schedule'", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+
+		wg := sync.WaitGroup{}
+		defer wg.Wait()
+		defer cancel()
+
+		go func() {
+			wg.Add(1)
+			runRefreshAndConsolidateLoop(ctx, logger, 5*time.Second, fakeStore)
+			wg.Done()
+		}()
+
+		Eventually(func() int {
+			return fakeStore.RefreshCallCount()
+		}).Should(Equal(1))
+
+		Eventually(func() int {
+			return fakeStore.ConsolidateAllCallCount()
+		}).Should(Equal(1))
+	})
+
 	It("should not call Consolidate if Refresh fails", func() {
 		fakeStore.RefreshReturns(fmt.Errorf("some-error"))
 

--- a/testenv/db.go
+++ b/testenv/db.go
@@ -65,6 +65,9 @@ func Open(cfg eventstore.Config) (*TempDB, error) {
 	if err := s.Init(); err != nil {
 		return nil, err
 	}
+	if err := s.Refresh(); err != nil {
+		return nil, err
+	}
 	tdb.Schema = s
 	return tdb, nil
 }


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/184071069

See commit messages for more details.

Running `regenerateEvents()` as part of `EventStore.Init()` means the collector process can't complete initialization of all its' worker loops until that has finished. This can become a problem if `regenerateEvents()` takes a very long time or is likely to fail, in which case the collection worker-loops may never get started at all - which is bad because they gather data which we _may_ not get another chance to.

Instead, ensure the asynchronous event processor worker runs `regenerateEvents()` immediately once it is started, which, as it happens is very (very) shortly after it would have been started in the first place.

How to review
-----

Deploy to a dev env, check the acceptance & integration tests continue to pass.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
