### PR TITLE
`App.Init()`: don't `store.ConsolidateAll()` before returning

### DIFF
--- a/main_app.go
+++ b/main_app.go
@@ -37,9 +37,6 @@ func (app *App) Init() error {
 	if err := app.historicDataStore.Init(); err != nil {
 		return err
 	}
-	if err := app.store.ConsolidateAll(); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/184071069

A fixup to #169 due to the realization in https://github.com/alphagov/paas-billing/pull/169#issuecomment-1378991557

We've removed the initial store `Refresh()` that this call implicitly relied upon and this now fails given a clean database to start on.

As with the removal of the initial `Refresh()`, the `ConsolidateAll()` gets called anyway as part of the event processing loop and, from an external process/client's point of view, will still get called just about as soon as it would have otherwise due to the initial run the event processing loop now does immediately when started. the only difference is we're starting the fetching loops before we move on to that.

How to review
-----

Deploy to a dev env? (I haven't yet)

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
