### PR TITLE
Restrict all-org usage & billable events requests to admins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,14 +118,14 @@ integration:
 .PHONY: smoke
 smoke:
 	## Runs the api acceptance tests against a dev environment as a smoke test to check
-	$(eval export CF_BEARER_TOKEN=$(shell cf oauth-token | cut -d' ' -f2))
+	$(eval export CF_ADMIN_BEARER_TOKEN ?= $(shell cf oauth-token | cut -d' ' -f2))
 	$(eval export BILLING_API_URL ?= http://$(API_LISTENER))
 	echo "smoke test enabled against ${BILLING_API_URL}"
 	go run github.com/onsi/ginkgo/v2/ginkgo --label-filter="smoke" -r acceptance_tests
 
 .PHONY: acceptance
 acceptance:
-	$(eval export CF_BEARER_TOKEN=$(shell cf oauth-token | cut -d' ' -f2))
+	$(eval export CF_ADMIN_BEARER_TOKEN ?= $(shell cf oauth-token | cut -d' ' -f2))
 	$(eval export BILLING_API_URL ?= http://$(API_LISTENER))
 	$(eval export METRICSPROXY_API_URL ?= http://$(PROXYMETRICS_LISTENER))
 	go run github.com/onsi/ginkgo/v2/ginkgo -r acceptance_tests

--- a/acceptance_tests/acceptance_tests_suite_test.go
+++ b/acceptance_tests/acceptance_tests_suite_test.go
@@ -14,7 +14,9 @@ func TestAcceptanceTests(t *testing.T) {
 }
 
 var (
-	BillingAPIURLFromEnv   = os.Getenv("BILLING_API_URL")
-	CFBearerTokenFromEnv   = os.Getenv("CF_BEARER_TOKEN")
-	MetricsProxyURLFromEnv = os.Getenv("METRICSPROXY_API_URL")
+	BillingAPIURLFromEnv            = os.Getenv("BILLING_API_URL")
+	CFAdminBearerTokenFromEnv       = os.Getenv("CF_ADMIN_BEARER_TOKEN")
+	CFNonAdminBearerTokenFromEnv    = os.Getenv("CF_NONADMIN_BEARER_TOKEN")
+	CFNonAdminBillingManagerOrgGUID = os.Getenv("CF_NONADMIN_BILLING_MANAGER_ORG_GUID")
+	MetricsProxyURLFromEnv          = os.Getenv("METRICSPROXY_API_URL")
 )

--- a/acceptance_tests/auth_test.go
+++ b/acceptance_tests/auth_test.go
@@ -1,0 +1,352 @@
+package acceptance_tests_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Auth-related acceptance tests", func() {
+	type eventCommon struct {
+		OrgGUID string `json:"org_guid"`
+		EventGUID string `json:"event_guid"`
+	}
+
+	eventCommonTests := func(endpointPath string) {
+		var (
+			orgGUIDWithEvents string
+			httpClient = &http.Client{}
+			lastMonth = time.Now().AddDate(0, -1, 0).Format("2006-01-02")
+			nextMonth = time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+		)
+
+		BeforeEach(func() {
+			By("Selecting an arbitrary org id with events", func() {
+				Eventually(func() bool {
+					u, err := url.Parse(BillingAPIURLFromEnv)
+					Expect(err).ToNot(HaveOccurred())
+					u = u.JoinPath(endpointPath)
+					q := u.Query()
+					q.Set("range_start", lastMonth)
+					q.Set("range_stop", nextMonth)
+					u.RawQuery = q.Encode()
+
+					req, err := http.NewRequest("GET", u.String(), nil)
+					Expect(err).ToNot(HaveOccurred())
+					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFAdminBearerTokenFromEnv))
+					res, err := httpClient.Do(req)
+					Expect(err).ToNot(HaveOccurred())
+					data, err := ioutil.ReadAll(res.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(res.StatusCode).To(Equal(200))
+
+					var events []eventCommon
+					err = json.Unmarshal(data, &events)
+					Expect(err).ToNot(HaveOccurred())
+
+					if len(events) < 1 {
+						return false
+					}
+
+					// picking the same org as CFNonAdminBillingManagerOrgGUID
+					// would screw up the non-admin tests
+					orgGUIDWithEvents = ""
+					for _, event := range events {
+						if CFNonAdminBillingManagerOrgGUID == "" || event.OrgGUID != CFNonAdminBillingManagerOrgGUID {
+							orgGUIDWithEvents = event.OrgGUID
+							break
+						}
+					}
+					if orgGUIDWithEvents == "" {
+						return false
+					}
+					return true
+				}, 4*time.Minute, 20*time.Second).Should(Equal(true), "Gave up waiting for events to be collected")
+			})
+		})
+
+		Context("Without an auth token", func () {
+			It("Returns 401 for single-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("org_guid", orgGUIDWithEvents)
+				q.Set("range_start", "2001-01-01")
+				q.Set("range_stop", "2001-01-02")
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				res, err := httpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(res.StatusCode).To(Equal(401))
+
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(data).To(MatchJSON(`{
+					"error": "no access_token in request"
+				}`))
+			})
+
+			It("Returns 401 for any-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("range_start", "2001-01-01")
+				q.Set("range_stop", "2001-01-02")
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				res, err := httpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(res.StatusCode).To(Equal(401))
+
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(data).To(MatchJSON(`{
+					"error": "no access_token in request"
+				}`))
+			})
+		})
+
+		Context("With an admin auth token", func () {
+			It("Returns events for single-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("org_guid", orgGUIDWithEvents)
+				q.Set("range_start", lastMonth)
+				q.Set("range_stop", nextMonth)
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(200))
+
+				var events []eventCommon
+				err = json.Unmarshal(data, &events)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(events)).To(BeNumerically(">", 0))
+				for _, ev := range events {
+					Expect(ev.OrgGUID).To(Equal(orgGUIDWithEvents))
+					Expect(ev.EventGUID).ToNot(BeEmpty())
+				}
+			})
+
+			It("Returns events for multi-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("org_guid", orgGUIDWithEvents)
+				q.Add("org_guid", CFNonAdminBillingManagerOrgGUID)
+				q.Set("range_start", lastMonth)
+				q.Set("range_stop", nextMonth)
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(200))
+
+				var events []eventCommon
+				err = json.Unmarshal(data, &events)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(events)).To(BeNumerically(">", 2))
+				foundOrgGUIDWithEvents := false
+				foundCFNonAdminBillingManagerOrgGUID := false
+				for _, ev := range events {
+					Expect(ev.EventGUID).ToNot(BeEmpty())
+					switch ev.OrgGUID {
+						case orgGUIDWithEvents:
+							foundOrgGUIDWithEvents = true
+						case CFNonAdminBillingManagerOrgGUID:
+							foundCFNonAdminBillingManagerOrgGUID = true
+						default:
+							Expect(false).To(BeTrue())
+					}
+				}
+				Expect(foundOrgGUIDWithEvents).To(BeTrue())
+				Expect(foundCFNonAdminBillingManagerOrgGUID).To(BeTrue())
+			})
+
+			It("Returns events for any-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("range_start", lastMonth)
+				q.Set("range_stop", nextMonth)
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(200))
+
+				var events []eventCommon
+				err = json.Unmarshal(data, &events)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(events)).To(BeNumerically(">", 0))
+			})
+		})
+
+		Context("With a non-admin auth token", func () {
+			It("Returns events for single-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("org_guid", CFNonAdminBillingManagerOrgGUID)
+				q.Set("range_start", lastMonth)
+				q.Set("range_stop", nextMonth)
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFNonAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(200))
+
+				var events []eventCommon
+				err = json.Unmarshal(data, &events)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(events)).To(BeNumerically(">", 0))
+				for _, ev := range events {
+					Expect(ev.OrgGUID).To(Equal(CFNonAdminBillingManagerOrgGUID))
+					Expect(ev.EventGUID).ToNot(BeEmpty())
+				}
+			})
+
+			It("Returns 401 for single-org requests for an unrelated org", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("org_guid", orgGUIDWithEvents)
+				q.Set("range_start", lastMonth)
+				q.Set("range_stop", nextMonth)
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFNonAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+
+				Expect(res.StatusCode).To(Equal(401))
+
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(data).To(MatchJSON(fmt.Sprintf(`{
+					"error": "invalid credentials: authorizer: no access to organisation: %s"
+				}`, orgGUIDWithEvents)))
+			})
+
+			It("Returns 401 for multi-org requests covering an unrelated org", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("org_guid", orgGUIDWithEvents)
+				q.Add("org_guid", CFNonAdminBillingManagerOrgGUID)
+				q.Set("range_start", lastMonth)
+				q.Set("range_stop", nextMonth)
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFNonAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+
+				Expect(res.StatusCode).To(Equal(401))
+
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(data).To(MatchJSON(fmt.Sprintf(`{
+					"error": "invalid credentials: authorizer: no access to organisation: %s"
+				}`, orgGUIDWithEvents)))
+			})
+
+			It("Returns 401 for any-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				q := u.Query()
+				q.Set("range_start", lastMonth)
+				q.Set("range_stop", nextMonth)
+				u.RawQuery = q.Encode()
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFNonAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+
+				Expect(res.StatusCode).To(Equal(401))
+
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(data).To(MatchJSON(`{
+					"error": "invalid credentials: only admins are allowed to access billing for all organisations"
+				}`))
+			})
+
+			It("Returns 401 for sneaky any-org requests", func() {
+				u, err := url.Parse(BillingAPIURLFromEnv)
+				Expect(err).ToNot(HaveOccurred())
+				u = u.JoinPath(endpointPath)
+				u.RawQuery = fmt.Sprintf(
+					"range_start=%s&range_stop=%s&org_guid=%%",
+					lastMonth,
+					nextMonth,
+				)
+
+				req, err := http.NewRequest("GET", u.String(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", CFNonAdminBearerTokenFromEnv))
+				res, err := httpClient.Do(req)
+
+				Expect(res.StatusCode).To(Equal(401))
+
+				data, err := ioutil.ReadAll(res.Body)
+				Expect(data).To(MatchJSON(`{
+					"error": "invalid credentials: only admins are allowed to access billing for all organisations"
+				}`))
+			})
+		})
+	}
+
+	Context("/usage_events", func() {
+		eventCommonTests("usage_events");
+	})
+
+	Context("/billable_events", func() {
+		eventCommonTests("billable_events");
+	})
+})

--- a/acceptance_tests/basic_test.go
+++ b/acceptance_tests/basic_test.go
@@ -19,14 +19,14 @@ var (
 	metricsProxyURL *url.URL
 )
 
-var _ = Describe("Acceptance", func() {
+var _ = Describe("Basic acceptance tests", func() {
 	Context("Billing API", Label("smoke"), func() {
 		BeforeEach(func() {
-			Expect(BillingAPIURLFromEnv).ToNot(BeEmpty(), "Billing API was empty")
+			Expect(BillingAPIURLFromEnv).ToNot(BeEmpty(), "Billing API URL was empty")
 			billingAPIURL, err = url.Parse(BillingAPIURLFromEnv)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(CFBearerTokenFromEnv).ToNot(BeEmpty(), "Bearer token was empty")
+			Expect(CFAdminBearerTokenFromEnv).ToNot(BeEmpty(), "Bearer token was empty")
 		})
 
 		It("can get pricing plans from api", func() {
@@ -57,7 +57,7 @@ var _ = Describe("Acceptance", func() {
 			req, err := http.NewRequest("GET", billingAPIURL.String(), nil)
 			Expect(err).ToNot(HaveOccurred())
 			headers := req.Header
-			headers.Set("Authorization", fmt.Sprintf("Bearer %s", CFBearerTokenFromEnv))
+			headers.Set("Authorization", fmt.Sprintf("Bearer %s", CFAdminBearerTokenFromEnv))
 			req.Header = headers
 
 			client := &http.Client{}

--- a/apiserver/auth/uaa_authorizer.go
+++ b/apiserver/auth/uaa_authorizer.go
@@ -79,6 +79,18 @@ func (a *ClientAuthorizer) HasBillingAccess(requestedOrgs []string) (bool, error
 	if err != nil {
 		return false, err
 	}
+	if len(requestedOrgs) == 0 {
+		isAdmin, err := a.Admin()
+		if err != nil {
+			return false, err
+		}
+
+		if !isAdmin {
+			return false, errors.New("only admins are allowed to access billing for all organisations")
+		}
+
+		return true, nil
+	}
 	billingManagerOrganisations, err := cf.ListUserBillingManagedOrgs(a.claims.UserID)
 	if err != nil {
 		return false, err

--- a/apiserver/server_billable_handler.go
+++ b/apiserver/server_billable_handler.go
@@ -2,12 +2,7 @@ package apiserver
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-
-	"io"
-
-	"strings"
 
 	"github.com/alphagov/paas-billing/apiserver/auth"
 	"github.com/alphagov/paas-billing/eventio"
@@ -16,6 +11,18 @@ import (
 
 func BillableEventsHandler(store eventio.BillableEventReader, consolidatedStore eventio.ConsolidatedBillableEventReader, uaa auth.Authenticator) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		sentOKHeader := false
+		sendOKHeader := func() error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+			c.Response().WriteHeader(http.StatusOK)
+			if _, err := c.Response().Write([]byte("[\n")); err != nil {
+				return err
+			}
+			c.Response().Flush()
+			sentOKHeader = true
+			return nil
+		}
+
 		requestedOrgs := c.Request().URL.Query()["org_guid"]
 		if ok, err := authorize(c, uaa, requestedOrgs); err != nil {
 			return echo.NewHTTPError(http.StatusUnauthorized, err)
@@ -35,118 +42,66 @@ func BillableEventsHandler(store eventio.BillableEventReader, consolidatedStore 
 		storeCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// query the store
-		rowOfRows := RowOfRows{}
-		defer rowOfRows.Close()
-
 		months, err := filter.SplitByMonth()
 		if err != nil {
 			return err
 		}
+
+		delim := ""
 		for _, monthFilter := range months {
-			isConsolidated, err := consolidatedStore.IsRangeConsolidated(monthFilter)
+			err := func () error {  // so we can use defer in-loop
+				isConsolidated, err := consolidatedStore.IsRangeConsolidated(monthFilter)
+				if err != nil {
+					return err
+				}
+				var rows eventio.BillableEventRows
+				if isConsolidated {
+					rows, err = consolidatedStore.GetConsolidatedBillableEventRows(storeCtx, monthFilter)
+				} else {
+					rows, err = store.GetBillableEventRows(storeCtx, monthFilter)
+				}
+				if err != nil {
+					return err
+				}
+				defer rows.Close()
+
+				next := rows.Next()
+				for next {
+					b, err := rows.EventJSON()
+					if err != nil {
+						return err
+					}
+					if !sentOKHeader {
+						// this is sent as late as possible because any errors encountered after
+						// this won't be communicated to the client correctly
+						if err := sendOKHeader(); err != nil {
+							return err
+						}
+					}
+					if _, err := c.Response().Write([]byte(delim)); err != nil {
+						return err
+					}
+					if _, err := c.Response().Write(b); err != nil {
+						return err
+					}
+					delim = ",\n"
+					next = rows.Next()
+					c.Response().Flush()
+				}
+				return nil
+			}()
 			if err != nil {
 				return err
 			}
-			var rows eventio.BillableEventRows
-			if isConsolidated {
-				rows, err = consolidatedStore.GetConsolidatedBillableEventRows(storeCtx, monthFilter)
-			} else {
-				rows, err = store.GetBillableEventRows(storeCtx, monthFilter)
-			}
-			if err != nil {
+		}
+		if !sentOKHeader {
+			if err := sendOKHeader(); err != nil {
 				return err
 			}
-			rowOfRows.RowsCollection = append(rowOfRows.RowsCollection, rows)
 		}
-
-		// stream response to client
-		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
-		c.Response().WriteHeader(http.StatusOK)
-		return WriteRowsAsJson(c.Response(), c.Response(), &rowOfRows)
-	}
-}
-
-func WriteRowsAsJson(writer io.Writer, flusher http.Flusher, rows eventio.BillableEventRows) error {
-	if _, err := writer.Write([]byte("[\n")); err != nil {
-		return err
-	}
-	flusher.Flush()
-	next := rows.Next()
-	delim := "\n"
-	for next {
-		b, err := rows.EventJSON()
-		if err != nil {
+		if _, err := c.Response().Write([]byte("\n]\n")); err != nil {
 			return err
 		}
-		if _, err := writer.Write(b); err != nil {
-			return err
-		}
-		next = rows.Next()
-		if next {
-			delim = ",\n"
-		} else {
-			delim = "\n"
-		}
-		if _, err := writer.Write([]byte(delim)); err != nil {
-			return err
-		}
-		flusher.Flush()
-	}
-	if _, err := writer.Write([]byte("]\n")); err != nil {
-		return err
-	}
-	flusher.Flush()
-	return rows.Err()
-}
-
-type RowOfRows struct {
-	RowsCollection []eventio.BillableEventRows
-	index          int
-}
-
-func (r *RowOfRows) Next() bool {
-	if r.index >= len(r.RowsCollection) {
-		return false
-	}
-	if r.RowsCollection[r.index].Next() {
-		return r.Err() == nil
-	}
-	r.index = r.index + 1
-	return r.Next()
-}
-
-func (r *RowOfRows) Close() error {
-	errs := []string{}
-	for _, r := range r.RowsCollection {
-		err := r.Close()
-		if err != nil {
-			errs = append(errs, err.Error())
-		}
-	}
-	if len(errs) == 0 {
 		return nil
 	}
-	return fmt.Errorf("errors happened calling RowOfRows.Close(): %s", strings.Join(errs, " | "))
-}
-
-func (r *RowOfRows) Err() error {
-	if r.index >= len(r.RowsCollection) {
-		return nil
-	}
-	return r.RowsCollection[r.index].Err()
-}
-
-func (r *RowOfRows) EventJSON() ([]byte, error) {
-	if r.index >= len(r.RowsCollection) {
-		return nil, fmt.Errorf("no more data in RowsCollection")
-	}
-	return r.RowsCollection[r.index].EventJSON()
-}
-
-func (r *RowOfRows) Event() (*eventio.BillableEvent, error) {
-	if r.index >= len(r.RowsCollection) {
-		return nil, fmt.Errorf("no more data in RowsCollection")
-	}
-	return r.RowsCollection[r.index].Event()
 }

--- a/apiserver/server_usage_handler_test.go
+++ b/apiserver/server_usage_handler_test.go
@@ -49,7 +49,7 @@ var _ = Describe("UsageEventsHandler", func() {
 
 	It("should return error if no token in request", func() {
 		fakeAuthenticator.NewAuthorizerReturns(nil, nil)
-		req := httptest.NewRequest(echo.GET, "/usage_events?orgGUID="+orgGUID1, nil)
+		req := httptest.NewRequest(echo.GET, "/usage_events?org_guid="+orgGUID1, nil)
 		res := httptest.NewRecorder()
 
 		e := New(cfg)
@@ -66,7 +66,7 @@ var _ = Describe("UsageEventsHandler", func() {
 	It("should return error on authentication error", func() {
 		authErr := errors.New("auth-error")
 		fakeAuthenticator.NewAuthorizerReturns(nil, authErr)
-		req := httptest.NewRequest(echo.GET, "/usage_events?orgGUID="+orgGUID1, nil)
+		req := httptest.NewRequest(echo.GET, "/usage_events?org_guid="+orgGUID1, nil)
 		req.Header.Set("Authorization", "bearer "+token)
 		res := httptest.NewRecorder()
 
@@ -83,7 +83,7 @@ var _ = Describe("UsageEventsHandler", func() {
 
 	It("should return error on malformed Authorization header", func() {
 		fakeAuthenticator.NewAuthorizerReturns(nil, nil)
-		req := httptest.NewRequest(echo.GET, "/usage_events?orgGUID="+orgGUID1, nil)
+		req := httptest.NewRequest(echo.GET, "/usage_events?org_guid="+orgGUID1, nil)
 		req.Header.Set("Authorization", token)
 		res := httptest.NewRecorder()
 


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/185167233

The original aim of this was to enforce permissions boundaries in `/usage_events` (and `/billable_events`), but the scope had to expand to put in place some tests that would actually _cover_ this. And I wanted to add _end-to-end_ tests because it was precisely the piecemeal, heavily-mocked unit test approach that allowed this to slip through in the first place.

So this expands the "acceptance tests" (run by our `create-cloudfoundry` pipeline following a live deployment) to also test requests on behalf of "real" admin _and_ non-admin users. The idea being that a failure in staging will prevent deployment of broken code to prod.

Writing these tests also uncovered a few problems with the `/billable_events` handler, due to a previous attempt at saving app memory, though it was at the cost of db server memory and connections. This allowed a single request for a large date range to exhaust the database's connections. See commit comment for more detail.

I removed that mechanism because running out of app memory is far more manageable than running out of db memory & connections. It does however expose the problem that the design of both the `/usage_events` and `/billable_events` endpoints, not having any paging (or even result-limiting) mechanisms, imply to clients they can do the impossible - return an infinite number of results without issue. The current half-solution is to use streaming http responses, but this has the downside that it breaks proper error communication - once the `200` status code has been sent at the beginning of the response, there's no going back on that and any errors encountered later on in the request processing will manifest to the client as either an in-body error message, truncated response or TCP-level failure.

My suggestion would be to either add a basic result-limiting mechanism (hard to shoehorn in to an existing REST interface, and made more complicated by our existing "streaming response" mechanism) or accumulating the response in a gzipped buffer before returning it (echo's "gzip" middleware will likely have the same problem as streaming responses, only starting to compress after the status line is sent).

So instead of making this PR any bigger I left the latter problem unsolved, instead limiting the size of requests used in my acceptance tests.

How to review
-----

Describe the steps required to test the changes.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
