### PR TITLE
added a check and unit test for jwt expiry

### DIFF
--- a/apiserver/auth/uaa_authorizer.go
+++ b/apiserver/auth/uaa_authorizer.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	jwt "github.com/dgrijalva/jwt-go"
@@ -201,6 +202,7 @@ func (a *ClientAuthorizer) composeClaims() error {
 	if err != nil {
 		return err
 	}
+
 	if !token.Valid {
 		return fmt.Errorf("token invalid")
 	}
@@ -210,6 +212,11 @@ func (a *ClientAuthorizer) composeClaims() error {
 	}
 
 	a.claims = claims
+
+	//check that the token has not expired
+	if a.claims.ExpiresAt < time.Now().Unix() {
+		return errors.New("token expired")
+	}
 
 	return nil
 }


### PR DESCRIPTION
What
----

Added code to uaa_authorizer.go to throw an error if the jwt token has expired
Added a unit test for the same

How to review
-----

Look at the code
Run the unit tests
Deploy the new version and try to call the API with a known expired token 

Who can review
-----

Any paas-dev

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
