### PR TITLE
Update to go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-billing
 
-go 1.20
+go 1.21
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -8,6 +8,6 @@ applications:
     health-check-type: http
     stack: cflinuxfs3
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-billing
     command: ./bin/paas-billing api

--- a/manifest-collector.yml
+++ b/manifest-collector.yml
@@ -8,6 +8,6 @@ applications:
     buildpack: go_buildpack
     health-check-type: http
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-billing
     command: ./bin/paas-billing collector

--- a/manifest-metricsproxy.yml
+++ b/manifest-metricsproxy.yml
@@ -8,7 +8,7 @@ applications:
     buildpack: go_buildpack
     health-check-type: http
     env:
-      GOVERSION: go1.20
+      GOVERSION: go1.21
       GOPACKAGENAME: github.com/alphagov/paas-billing
       APP_NAMES:
     command: ./bin/paas-billing proxymetrics


### PR DESCRIPTION
## What
Use go v1.21

## Why
A recent go buildpack update is dropping support for go 1.20, so updating to 1.21 will let us update this buildpack

## How to review
Ensure that the everything deploys okay to a dev environment

## Who can review
Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
